### PR TITLE
Fixes to setsockopt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.o
 *.obj
 
-# Object file directors with EPICS builf
+# Object file directories with EPICS build
 O.*
 
 # Precompiled Headers

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.o
 *.obj
 
+# Object file directors with EPICS builf
+O.*
+
 # Precompiled Headers
 *.gch
 *.pch

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+V 2.6.2 07/18/2016 Mark Rivers <rivers@cars.uchicago.edu>
+Fix setsockopt in acceptFactory.cc to use SO_REUSEADDR rather than SO_REUSEPORT on all platforms.
+Fix setsockopt in acceptFactory.cc to use SO_EXCLUSIVEADDRUSE on WIN32 and SO_EXCLBIND on Solaris 
+See this article for information: http://stackoverflow.com/questions/14388706/socket-options-so-reuseaddr-and-so-reuseport-how-do-they-differ-do-they-mean-t
+
 V 2.6.1 05/19/2015 Ralph Lange <Ralph.Lange@gmx.de>
 Moved upstream project to GitHub.
 Fixed URL for sysv-scripts in README.

--- a/acceptFactory.cc
+++ b/acceptFactory.cc
@@ -14,10 +14,6 @@
 #include <arpa/inet.h>
 #include <string.h>
 
-#ifndef SO_REUSEPORT               // Linux doesn't know SO_REUSEPORT
-#define SO_REUSEPORT SO_REUSEADDR
-#endif
-
 #include "procServ.h"
 
 class acceptItem : public connectionItem
@@ -61,7 +57,13 @@ acceptItem::acceptItem(int port, bool local, bool readonly)
     _fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     assert(_fd>0);
 
-    setsockopt(_fd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+    setsockopt(_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+#ifdef SOLARIS
+    setsockopt(_fd, SOL_SOCKET, SO_EXCLBIND, &optval, sizeof(optval));
+#endif
+#ifdef _WIN32
+    setsockopt(_fd, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, &optval, sizeof(optval));
+#endif
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;


### PR DESCRIPTION
I have made the changes you suggested.  I am not sure about the setsockopt on _WIN32.  procServ actually only builds on Cygwin for Windows, and Cygwin does not define _WIN32 by default.  But Cygwin also supplies its own socket library on top of Winsock2, so it is not clear if SO_EXCLUSIVEADDRUSE is actually needed on Cygwin or not.  What I have done compiles and runs on Cygwin, but I don't know how to test if the SO_EXCLUSIVEADDRUSE option is actually having any effect.

I have made the notes in the ChangeLog for 2.6.2.  You have notes for 2.6.1, but there is not yet a V2.6.1 tag on github.  So I suggest you first tag the current version as V2.6.1, and then add the V2.6.2 after merging this pull request.