### PR TITLE
FIX: call the hideWindow() method as long as the process is running.

### DIFF
--- a/procServ.cc
+++ b/procServ.cc
@@ -624,6 +624,7 @@ int main(int argc,char * argv[])
                 p = p->next;
             }
             OnPollTimeout();
+            hideWindow();
         }
     }
     ttySetCharNoEcho(false);
@@ -826,7 +827,6 @@ void forkAndGo()
 
         // Make sure we are not attached to a terminal
         setsid();
-        hideWindow();
     }
 }
 


### PR DESCRIPTION
On windows, with procserv compiled under cygwin,  if an ioc is started using procserv an empty cmd window (see below) stays in the foreground and on closing the cmd window, procserv is terminated. The commit fixes this issue.
Here's the command that I used to run the ioc with procserv:
```
@echo off
rem incase we do dynamic builds
if exist "dllPath.bat" (
	call dllPath.bat
)
if exist "C:\Epics\extensions\bin\%EPICS_HOST_ARCH%\procServ.exe" (
	procServ --allow -n "SIM-DETECTOR" -p pid.txt -L log.txt --logstamp -q -i ^D^C 3002 ..\..\bin\%EPICS_HOST_ARCH%\simDetectorApp.exe st.cmd
) else (
	..\..\bin\%EPICS_HOST_ARCH%\simDetectorApp.exe st.cmd
)
```

![procserv_emptycmd](https://cloud.githubusercontent.com/assets/6889474/18025565/63233482-6bfb-11e6-84c7-58cff2f0f6d2.PNG)
