### PR TITLE
systemd integration of procServ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ procServ.pdf
 # IDE configuration
 /QtC-*
 .deps
+
+# python
+*.pyc
+*.pyo

--- a/conserver.cf.example
+++ b/conserver.cf.example
@@ -1,0 +1,15 @@
+config * {
+}
+default full {
+	rw *;
+}
+default * {
+	logfile /var/log/conserver/&.log;
+	timestamp "";
+	include full;
+}
+#include /etc/conserver/procs.cf
+access * {
+	trusted 127.0.0.1;
+	allowed 127.0.0.1;
+}

--- a/debian/control
+++ b/debian/control
@@ -35,6 +35,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
          procserv (>= ${source:Version}), procserv (<< ${source:Version}.1~),
          python3-procserv (= ${source:Version}),
          procserv-rsyslog | procserv-manual-logging,
+         telnet,
          ${python3:Depends},
 Description: Process server with telnet console and log access
  procServ is a wrapper that starts an arbitrary command as a child process in

--- a/debian/control
+++ b/debian/control
@@ -2,16 +2,18 @@ Source: procserv
 Section: utils
 Priority: optional
 Maintainer: Ralph Lange <ralph.lange@gmx.de>
-Build-Depends: debhelper (>= 9), libtelnet-dev
+Build-Depends: debhelper (>= 9), libtelnet-dev,
+               dh-python, python3-all,
 Standards-Version: 3.9.8
 Vcs-Git: git://anonscm.debian.org/collab-maint/procserv.git
 Vcs-Browser: https://anonscm.debian.org/cgit/collab-maint/procserv.git
+X-Python3-Version: 3.4
 Homepage: https://github.com/ralphlange/procServ
 
 Package: procserv
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Suggests: telnet
+Depends: ${shlibs:Depends}, ${misc:Depends},
+Suggests: telnet, procserv-systemd,
 Description: Process server with telnet console and log access
  procServ is a wrapper that starts an arbitrary command as a child process in
  the background, connecting its standard input and output to a TCP port for
@@ -25,3 +27,43 @@ Description: Process server with telnet console and log access
  is done best on a higher level, using a package like conserver.
  .
  For security reasons, procServ only accepts connections from localhost.
+
+Package: procserv-systemd
+Section: admin
+Architecture: all
+Depends: ${shlibs:Depends}, ${misc:Depends},
+         procserv (>= ${source:Version}), procserv (<< ${source:Version}.1~),
+         python3-procserv (= ${source:Version}),
+         ${python3:Depends},
+Description: Process server with telnet console and log access
+ procServ is a wrapper that starts an arbitrary command as a child process in
+ the background, connecting its standard input and output to a TCP port for
+ telnet access. It supports logging, child restart (manual or automatic on
+ exit), and more.
+ .
+ procServ does not have the rich feature set of the screen utility,
+ but is intended to provide running a command in a system service style,
+ in a small, robust way.
+ Handling multiple users, authorization, authentication, central logging
+ is done best on a higher level, using a package like conserver.
+ .
+ This package contains support for controling procServ instances w/ systemd.
+
+Package: python3-procserv
+Section: python
+Architecture: all
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends},
+         procserv (>= ${source:Version}), procserv (<< ${source:Version}.1~),
+Description: Process server with telnet console and log access
+ procServ is a wrapper that starts an arbitrary command as a child process in
+ the background, connecting its standard input and output to a TCP port for
+ telnet access. It supports logging, child restart (manual or automatic on
+ exit), and more.
+ .
+ procServ does not have the rich feature set of the screen utility,
+ but is intended to provide running a command in a system service style,
+ in a small, robust way.
+ Handling multiple users, authorization, authentication, central logging
+ is done best on a higher level, using a package like conserver.
+ .
+ This package contains some python support scripts

--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,7 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends},
          procserv (>= ${source:Version}), procserv (<< ${source:Version}.1~),
          python3-procserv (= ${source:Version}),
+         procserv-rsyslog | procserv-manual-logging,
          ${python3:Depends},
 Description: Process server with telnet console and log access
  procServ is a wrapper that starts an arbitrary command as a child process in
@@ -67,3 +68,45 @@ Description: Process server with telnet console and log access
  is done best on a higher level, using a package like conserver.
  .
  This package contains some python support scripts
+
+Package: procserv-rsyslog
+Section: admin
+Architecture: all
+Depends: ${shlibs:Depends}, ${misc:Depends},
+         procserv-systemd (>= ${source:Version}), procserv-systemd (<< ${source:Version}.1~),
+         rsyslog, logrotate,
+Description: Process server with telnet console and log access
+ procServ is a wrapper that starts an arbitrary command as a child process in
+ the background, connecting its standard input and output to a TCP port for
+ telnet access. It supports logging, child restart (manual or automatic on
+ exit), and more.
+ .
+ procServ does not have the rich feature set of the screen utility,
+ but is intended to provide running a command in a system service style,
+ in a small, robust way.
+ Handling multiple users, authorization, authentication, central logging
+ is done best on a higher level, using a package like conserver.
+ .
+ This package contains rsyslog and logrotate configuration to pipe the
+ output of procServ controlled processes to individual log files.
+
+Package: procserv-manual-logging
+Section: admin
+Architecture: all
+Depends: ${shlibs:Depends}, ${misc:Depends},
+         procserv-systemd (>= ${source:Version}), procserv-systemd (<< ${source:Version}.1~),
+Description: Process server with telnet console and log access
+ procServ is a wrapper that starts an arbitrary command as a child process in
+ the background, connecting its standard input and output to a TCP port for
+ telnet access. It supports logging, child restart (manual or automatic on
+ exit), and more.
+ .
+ procServ does not have the rich feature set of the screen utility,
+ but is intended to provide running a command in a system service style,
+ in a small, robust way.
+ Handling multiple users, authorization, authentication, central logging
+ is done best on a higher level, using a package like conserver.
+ .
+ This package is a placeholder for use by admins who wish to provide
+ custom (or no) extra configuraiton of logging of procServ controlled
+ processes.

--- a/debian/procserv-rsyslog.logrotate
+++ b/debian/procserv-rsyslog.logrotate
@@ -1,0 +1,12 @@
+/var/log/procserv/*.log
+{
+    rotate 14
+    delaycompress
+    missingok
+    notifempty
+    size 10000000
+    sharedscripts
+    postrotate
+        invoke-rc.d rsyslog rotate > /dev/null
+    endscript
+}

--- a/debian/procserv-rsyslog.rsyslog
+++ b/debian/procserv-rsyslog.rsyslog
@@ -1,5 +1,5 @@
 $template ProcServFile,"/var/log/procserv/%programname%.log"
 
 # This is matching the SyslogIdentifier set by systemd
-:programname, startswith, "procServ-"  ?ProcServFile
-:programname, startswith, "procServ-"  ~
+:programname, startswith, "procserv-"  ?ProcServFile
+:programname, startswith, "procserv-"  ~

--- a/debian/procserv-rsyslog.rsyslog
+++ b/debian/procserv-rsyslog.rsyslog
@@ -1,0 +1,5 @@
+$template ProcServFile,"/var/log/procserv/%programname%.log"
+
+# This is matching the SyslogIdentifier set by systemd
+:programname, startswith, "procServ-"  ?ProcServFile
+:programname, startswith, "procServ-"  ~

--- a/debian/procserv-systemd.install
+++ b/debian/procserv-systemd.install
@@ -1,5 +1,6 @@
 usr/bin/manage-procs
 usr/bin/procServ-launcher
+usr/bin/prtelnet
 lib/systemd/system-generators/systemd-procserv-generator
 usr/lib/systemd/user-generators/systemd-procserv-generator
 conserver.cf.example usr/share/doc/procserv-systemd

--- a/debian/procserv-systemd.install
+++ b/debian/procserv-systemd.install
@@ -1,5 +1,5 @@
 usr/bin/manage-procs
 usr/bin/procServ-launcher
 lib/systemd/system-generators/systemd-procserv-generator
-lib/systemd/user-generators/systemd-procserv-generator
+usr/lib/systemd/user-generators/systemd-procserv-generator
 conserver.cf.example usr/share/doc/procserv-systemd

--- a/debian/procserv-systemd.install
+++ b/debian/procserv-systemd.install
@@ -1,0 +1,4 @@
+usr/bin/manage-procs
+usr/bin/procServ-launcher
+lib/systemd/system-generators/systemd-procserv-generator
+lib/systemd/user-generators/systemd-procserv-generator

--- a/debian/procserv-systemd.install
+++ b/debian/procserv-systemd.install
@@ -2,3 +2,4 @@ usr/bin/manage-procs
 usr/bin/procServ-launcher
 lib/systemd/system-generators/systemd-procserv-generator
 lib/systemd/user-generators/systemd-procserv-generator
+conserver.cf.example usr/share/doc/procserv-systemd

--- a/debian/procserv.install
+++ b/debian/procserv.install
@@ -1,0 +1,2 @@
+usr/bin/procServ
+usr/share/doc/procserv

--- a/debian/python3-procserv.install
+++ b/debian/python3-procserv.install
@@ -1,0 +1,1 @@
+usr/lib/python*

--- a/debian/rules
+++ b/debian/rules
@@ -4,13 +4,34 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@
+	dh $@ --with python3
+
+override_dh_auto_clean:
+	# workaround to keep lower priority 'makefile' from nuking ./configure
+	[ -f Makefile ] && dh_auto_clean -Sautoconf || true
+	dh_auto_clean -Spybuild
 
 override_dh_auto_configure:
-	dh_auto_configure -- --docdir=\$${prefix}/share/doc/procserv
+	dh_auto_configure -Sautoconf -- --docdir=\$${prefix}/share/doc/procserv
+	dh_auto_configure -Spybuild
+
+override_dh_auto_build:
+	dh_auto_build -Sautoconf
+	dh_auto_build -Spybuild
 
 override_dh_auto_install:
-	dh_auto_install
+	dh_auto_install -Sautoconf
+	dh_auto_install -Spybuild
 	# Remove extra ChangeLog and COPYING files installed by upstream make
-	rm $(CURDIR)/debian/procserv/usr/share/doc/procserv/ChangeLog
-	rm $(CURDIR)/debian/procserv/usr/share/doc/procserv/COPYING
+	rm $(CURDIR)/debian/tmp/usr/share/doc/procServ/ChangeLog
+	rm $(CURDIR)/debian/tmp/usr/share/doc/procServ/COPYING
+	# /doc dir should match package name
+	mv $(CURDIR)/debian/tmp/usr/share/doc/procServ $(CURDIR)/debian/tmp/usr/share/doc/procserv
+	install -d $(CURDIR)/debian/tmp/lib/systemd/system-generators
+	cp systemd-procserv-generator-system $(CURDIR)/debian/tmp/lib/systemd/system-generators/systemd-procserv-generator
+	install -d $(CURDIR)/debian/tmp/lib/systemd/user-generators
+	cp systemd-procserv-generator-user $(CURDIR)/debian/tmp/lib/systemd/user-generators/systemd-procserv-generator
+
+
+override_dh_install:
+	dh_install --fail-missing

--- a/debian/rules
+++ b/debian/rules
@@ -29,8 +29,8 @@ override_dh_auto_install:
 	mv $(CURDIR)/debian/tmp/usr/share/doc/procServ $(CURDIR)/debian/tmp/usr/share/doc/procserv
 	install -d $(CURDIR)/debian/tmp/lib/systemd/system-generators
 	cp systemd-procserv-generator-system $(CURDIR)/debian/tmp/lib/systemd/system-generators/systemd-procserv-generator
-	install -d $(CURDIR)/debian/tmp/lib/systemd/user-generators
-	cp systemd-procserv-generator-user $(CURDIR)/debian/tmp/lib/systemd/user-generators/systemd-procserv-generator
+	install -d $(CURDIR)/debian/tmp/usr/lib/systemd/user-generators
+	cp systemd-procserv-generator-user $(CURDIR)/debian/tmp/usr/lib/systemd/user-generators/systemd-procserv-generator
 
 
 override_dh_install:

--- a/debian/rules
+++ b/debian/rules
@@ -31,7 +31,8 @@ override_dh_auto_install:
 	cp systemd-procserv-generator-system $(CURDIR)/debian/tmp/lib/systemd/system-generators/systemd-procserv-generator
 	install -d $(CURDIR)/debian/tmp/usr/lib/systemd/user-generators
 	cp systemd-procserv-generator-user $(CURDIR)/debian/tmp/usr/lib/systemd/user-generators/systemd-procserv-generator
-
+	install -d $(CURDIR)/debian/procserv-rsyslog/etc/rsyslog.d
+	cp debian/procserv-rsyslog.rsyslog $(CURDIR)/debian/procserv-rsyslog/etc/rsyslog.d/procserv-rsyslog.conf
 
 override_dh_install:
 	dh_install --fail-missing

--- a/manage-procs
+++ b/manage-procs
@@ -1,0 +1,4 @@
+#!/usr/bin/python3
+
+from procServUtils.manage import getargs, main
+main(getargs())

--- a/procServ-launcher
+++ b/procServ-launcher
@@ -1,0 +1,4 @@
+#!/usr/bin/python3
+
+from procServUtils.launch import getargs, main
+main(getargs())

--- a/procServUtils/conf.py
+++ b/procServUtils/conf.py
@@ -1,0 +1,58 @@
+
+import os
+from functools import reduce
+from glob import glob
+
+def getgendir(user=False):
+    if user:
+        return os.path.expanduser('~/.config/procServ.d')
+    else:
+        return '/etc/procServ.d'
+
+def getrundir(user=False):
+    if user:
+        return os.environ['XDG_RUNTIME_DIR']
+    else:
+        return '/run'
+
+def getconffiles(user=False):
+    """Return a list of config file names
+    
+    Only those which actualy exist
+    """
+    if user:
+        files = map(os.path.expanduser, [
+            '~/.config/procServ.conf',
+            '~/.config/procServ.d/*.conf',
+        ])
+    else:
+        files = [
+            '/etc/procServ.conf',
+            '/etc/procServ.d/*.conf',
+        ]
+
+    # glob('') -> ['',]
+    # map(glob) produces a list of lists
+    # reduce by concatination into a single list
+    return reduce(list.__add__, map(glob, files), [])
+
+def getconf(user=False):
+    """Return a ConfigParser with one section per procServ instance
+    """
+    try:
+        from ConfigParser import SafeConfigParser as ConfigParser
+    except ImportError:
+        from configparser import ConfigParser
+    from glob import glob
+
+    C = ConfigParser({
+        'user':'nobody',
+        'group':'',
+        'chdir':'/',
+        'port':'-1',
+        'instance':'1',
+    })
+
+    C.read(getconffiles(user=user))
+
+    return C

--- a/procServUtils/conf.py
+++ b/procServUtils/conf.py
@@ -3,6 +3,11 @@ import os
 from functools import reduce
 from glob import glob
 
+try:
+    from ConfigParser import SafeConfigParser as ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
 def getgendir(user=False):
     if user:
         return os.path.expanduser('~/.config/procServ.d')
@@ -36,22 +41,20 @@ def getconffiles(user=False):
     # reduce by concatination into a single list
     return reduce(list.__add__, map(glob, files), [])
 
+_defaults = {
+    'user':'nobody',
+    'group':'nogroup',
+    'chdir':'/',
+    'port':'0',
+    'instance':'1',
+}
+
 def getconf(user=False):
     """Return a ConfigParser with one section per procServ instance
     """
-    try:
-        from ConfigParser import SafeConfigParser as ConfigParser
-    except ImportError:
-        from configparser import ConfigParser
     from glob import glob
 
-    C = ConfigParser({
-        'user':'nobody',
-        'group':'nogroup',
-        'chdir':'/',
-        'port':'0',
-        'instance':'1',
-    })
+    C = ConfigParser(_defaults)
 
     C.read(getconffiles(user=user))
 

--- a/procServUtils/conf.py
+++ b/procServUtils/conf.py
@@ -47,9 +47,9 @@ def getconf(user=False):
 
     C = ConfigParser({
         'user':'nobody',
-        'group':'',
+        'group':'nogroup',
         'chdir':'/',
-        'port':'-1',
+        'port':'0',
         'instance':'1',
     })
 

--- a/procServUtils/generator.py
+++ b/procServUtils/generator.py
@@ -26,6 +26,9 @@ ConditionPathIsDirectory=%(chdir)s
 Type=simple
 ExecStart=/usr/bin/procServ-launcher %(userarg)s %(name)s
 RuntimeDirectory=procserv-%(name)s
+StandardOutput=syslog
+StandardError=inherit
+SyslogIdentifier=procServ-%(name)s
 """%opts)
 
     if not user:

--- a/procServUtils/generator.py
+++ b/procServUtils/generator.py
@@ -8,7 +8,7 @@ def write_service(F, conf, sect, user=False):
         'user':conf.get(sect, 'user'),
         'group':conf.get(sect, 'group'),
         'chdir':conf.get(sect, 'chdir'),
-        'user':'--user' if user else '--system',
+        'userarg':'--user' if user else '--system',
     }
 
     F.write("""
@@ -24,8 +24,8 @@ ConditionPathIsDirectory=%(chdir)s
     F.write("""
 [Service]
 Type=simple
-ExecStart=/usr/bin/procServ-launcher %(user)s %(name)s
-RuntimeDirectory=procServ/%(name)s
+ExecStart=/usr/bin/procServ-launcher %(userarg)s %(name)s
+RuntimeDirectory=procserv-%(name)s
 """%opts)
 
     if not user:
@@ -45,7 +45,7 @@ def run(outdir, user=False):
     for sect in conf.sections():
         if not conf.getboolean(sect, 'instance'):
             continue
-        service = 'procserv@%s.service'%sect
+        service = 'procserv-%s.service'%sect
         ofile = os.path.join(outdir, service)
         with open(ofile+'.tmp', 'w') as F:
             write_service(F, conf, sect, user=user)

--- a/procServUtils/generator.py
+++ b/procServUtils/generator.py
@@ -28,7 +28,7 @@ ExecStart=/usr/bin/procServ-launcher %(userarg)s %(name)s
 RuntimeDirectory=procserv-%(name)s
 StandardOutput=syslog
 StandardError=inherit
-SyslogIdentifier=procServ-%(name)s
+SyslogIdentifier=procserv-%(name)s
 """%opts)
 
     if not user:

--- a/procServUtils/generator.py
+++ b/procServUtils/generator.py
@@ -1,0 +1,58 @@
+
+import sys, os
+from .conf import getconf
+
+def write_service(F, conf, sect, user=False):
+    opts = {
+        'name':sect,
+        'user':conf.get(sect, 'user'),
+        'group':conf.get(sect, 'group'),
+        'chdir':conf.get(sect, 'chdir'),
+        'user':'--user' if user else '--system',
+    }
+
+    F.write("""
+[Unit]
+Description=procServ for %(name)s
+After=network.target remote-fs.target
+ConditionPathIsDirectory=%(chdir)s
+"""%opts)
+
+    if conf.has_option(sect, 'host'):
+        F.write('ConditionHost=%s\n'%conf.get(sect, 'host'))
+
+    F.write("""
+[Service]
+Type=simple
+ExecStart=/usr/bin/procServ-launcher %(user)s %(name)s
+RuntimeDirectory=procServ/%(name)s
+"""%opts)
+
+    if not user:
+        F.write("""
+User=%(user)s
+Group=%(group)s
+"""%opts)
+
+    F.write("""
+[Install]
+WantedBy=multi-user.target
+"""%opts)
+
+def run(outdir, user=False):
+    conf = getconf(user=user)
+
+    for sect in conf.sections():
+        if not conf.getboolean(sect, 'instance'):
+            continue
+        service = 'procserv@%s.service'%sect
+        ofile = os.path.join(outdir, service)
+        with open(ofile+'.tmp', 'w') as F:
+            write_service(F, conf, sect, user=user)
+
+        os.rename(ofile+'.tmp', ofile)
+
+        # TODO: is WantedBy enough, or do we need to create symlinks ourselves?
+        #os.makedirs(os.path.join(outdir, 'multi-user.target.wants'), exists_ok=True)
+        #os.symlink(ofile,
+        #           os.path.join(outdir, 'multi-user.target.wants', service))

--- a/procServUtils/launch.py
+++ b/procServUtils/launch.py
@@ -52,6 +52,7 @@ def main(args):
     toexec = [
         procServ,
         '--foreground',
+        '--logfile', '<stdout>',
         '--name', name,
         '--ignore','^D^C^]',
         '--chdir',chdir,

--- a/procServUtils/launch.py
+++ b/procServUtils/launch.py
@@ -1,0 +1,64 @@
+
+import sys, os
+from .conf import getconf, getrundir
+
+try:
+    import shlex
+except ImportError:
+    from . import shlex
+
+procServ = '/usr/bin/procServ'
+
+def getargs():
+    from argparse import ArgumentParser
+    A = ArgumentParser()
+    A.add_argument('name', help='procServ instance name')
+    A.add_argument('--user', action='store_true', default=os.geteuid()!=0,
+                   help='Consider user config')
+    A.add_argument('--system', dest='user', action='store_false',
+                   help='Consider system config')
+    return A.parse_args()
+
+def main(args):
+    conf = getconf(user=args.user)
+
+    name, user = args.name, args.user
+
+    if not conf.has_section(name):
+        sys.stderr.write("Instance '%s' not found"%name)
+        sys.exit(1)
+
+    if not conf.getboolean(name, 'instance'):
+        sys.stderr.write("'%s' not an instance"%name)
+        sys.exit(1)
+
+    if not conf.has_option(name, 'command'):
+        sys.stderr.write("instance '%s' missing command="%name)
+        sys.exit(1)
+
+    chdir = conf.get(name, 'chdir')
+    cmd   = conf.get(name, 'command')
+    port  = conf.get(name, 'port')
+
+    rundir = getrundir(user=user)
+
+    env = {
+        'PROCSERV_NAME':name,
+        'IOCNAME':name,
+    }
+    env.update(os.environ)
+
+    cmd = [
+        procServ,
+        '--foreground',
+        '--name', name,
+        '--ignore','^D^C^]',
+        '--chdir',chdir,
+        '--info-file',os.path.join(rundir, 'procServ', name, 'info'), #/run/procServ/$NAME/info
+        '--port-spec', 'unix:%s/procServ/%s/control'%(rundir,name),
+        port,
+    ]+shlex.split(cmd)
+
+    os.chdir(chdir)
+    os.execve(cmd[0], cmd, env)
+    sys.exit(2) # never reached

--- a/procServUtils/launch.py
+++ b/procServUtils/launch.py
@@ -52,7 +52,7 @@ def main(args):
     toexec = [
         procServ,
         '--foreground',
-        '--logfile', '<stdout>',
+        '--logfile', '-',
         '--name', name,
         '--ignore','^D^C^]',
         '--chdir',chdir,

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -81,7 +81,7 @@ def addproc(conf, args):
     # ensure chdir is an absolute path
     args.chdir = os.path.abspath(os.path.join(os.getcwd(), args.chdir))
 
-    args.command[0] = os.path.abspath(os.path.join(args.chdir, args.chdir))
+    args.command[0] = os.path.abspath(os.path.join(args.chdir, args.command[0]))
 
     opts = {
         'name':args.name,

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -1,0 +1,143 @@
+
+import logging
+_log = logging.getLogger(__name__)
+
+import sys, os, errno
+import subprocess as SP
+
+from .conf import getconf, getrundir, getgendir
+
+try:
+    import shlex
+except ImportError:
+    from . import shlex
+
+systemctl = '/bin/systemctl'
+
+def status(conf, args, fp=None):
+    rundir=getrundir(user=args.user)
+    fp = fp or sys.stdout
+
+    for name in conf.sections():
+        if not conf.getboolean(name, 'instance'):
+            continue
+        fp.write('%s '%name)
+
+        pid = None
+        ports = []
+        try:
+            with open(os.path.join(rundir, 'procServ', name, 'info')) as F:
+                for line in map(str.strip, F):
+                    if line.startswith('pid:'):
+                        pid = int(line[4:])
+                    elif line.startswith('tcp:'):
+                        ports.append(line)
+                    elif line.startswith('unix:'):
+                        ports.append(line)
+        except Exception as e:
+            if getattr(e, 'errno',0)!=errno.ENOENT:
+                _log.exception('oops')
+
+        if pid is not None:
+            # Can we say if the process is actually running?
+            running = True
+            try:
+                os.kill(pid, 0)
+                # yup
+            except OSError as e:
+                if e.errno==errno.ESRCH:
+                    running = False
+                elif e.errno==errno.EPERM:
+                    pass # assume it's running as another user
+                else:
+                    _log.exception("Testing PID %s", pid)
+            fp.write('Running' if running else 'Dead')
+        else:
+            fp.write('Stopped')
+
+        fp.write('\n')
+
+def addproc(conf, args):
+    outdir = getgendir(user=args.user)
+    cfile = os.path.join(outdir, '%s.conf'%args.name)
+
+    if os.path.exists(cfile) and not args.force:
+        _log.error("Instance already exists @ %s", cfile)
+        sys.exit(1)
+
+    #if conf.has_section(args.name):
+    #    _log.error("Instance already exists")
+    #    sys.exit(1)
+
+    try:
+        os.makedirs(outdir)
+    except OSError as e:
+        if e.errno!=errno.EEXIST:
+            _log.exception('Creating directory "%s"', outdir)
+            raise
+
+    _log.info("Writing: %s", cfile)
+
+    # ensure chdir is an absolute path
+    args.chdir = os.path.abspath(os.path.join(os.getcwd(), args.chdir))
+
+    args.command[0] = os.path.abspath(os.path.join(args.chdir, args.chdir))
+
+    opts = {
+        'name':args.name,
+        'command': ' '.join(map(shlex.quote, args.command)),
+        'chdir':args.chdir,
+    }
+
+    with open(cfile+'.tmp', 'w') as F:
+        F.write("""
+[%(name)s]
+command = %(command)s
+chdir = %(chdir)s
+"""%opts)
+
+        if args.username: F.write("user = %s\n"%args.username)
+        if args.group: F.write("group = %s\n"%args.group)
+        if args.port: F.write("port = %s\n"%args.port)
+
+    os.rename(cfile+'.tmp', cfile)
+
+    _log.info('Trigger systemd reload')
+    SP.check_call([systemctl,
+                   '--user' if args.user else '--system',
+                   'daemon-reload'], shell=False)
+
+
+def getargs():
+    from argparse import ArgumentParser
+    P = ArgumentParser()
+    P.add_argument('--user', action='store_true', default=os.geteuid()!=0,
+                   help='Consider user config')
+    P.add_argument('--system', dest='user', action='store_false',
+                   help='Consider system config')
+
+    SP = P.add_subparsers()
+
+    S = SP.add_parser('status', help='List procServ instance state')
+    S.set_defaults(func=status)
+
+    S = SP.add_parser('add', help='Create a new procServ instance state')
+    S.add_argument('-C','--chdir', default=os.getcwd(), help='Run directory for instance')
+    S.add_argument('-P','--port', help='telnet port')
+    S.add_argument('-U','--user', dest='username')
+    S.add_argument('-G','--group')
+    S.add_argument('-f','--force', action='store_true', default=False)
+    S.add_argument('name', help='Instance name')
+    S.add_argument('command', nargs='+', help='Command')
+    S.set_defaults(func=addproc)
+
+    A = P.parse_args()
+    if not hasattr(A, 'func'):
+        P.print_help()
+        sys.exit(1)
+    return A
+
+def main(args):
+    logging.basicConfig(level=logging.DEBUG)
+    conf = getconf(user=args.user)
+    args.func(conf, args)

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -12,6 +12,12 @@ try:
 except ImportError:
     from . import shlex
 
+_levels = [
+    logging.WARN,
+    logging.INFO,
+    logging.DEBUG,
+]
+
 systemctl = '/bin/systemctl'
 
 def status(conf, args, fp=None):
@@ -25,37 +31,50 @@ def status(conf, args, fp=None):
 
         pid = None
         ports = []
+        infoname = os.path.join(rundir, 'procserv-%s'%name, 'info')
         try:
-            with open(os.path.join(rundir, 'procServ', name, 'info')) as F:
+            with open(infoname) as F:
+                _log.debug('Read %s', F.name)
                 for line in map(str.strip, F):
                     if line.startswith('pid:'):
                         pid = int(line[4:])
                     elif line.startswith('tcp:'):
-                        ports.append(line)
+                        ports.append(line[4:])
                     elif line.startswith('unix:'):
-                        ports.append(line)
+                        ports.append(line[5:])
         except Exception as e:
+            _log.debug('No info file %s', infoname)
             if getattr(e, 'errno',0)!=errno.ENOENT:
                 _log.exception('oops')
 
         if pid is not None:
+            _log.debug('Test PID %s', pid)
             # Can we say if the process is actually running?
             running = True
             try:
                 os.kill(pid, 0)
-                # yup
+                _log.debug('PID exists')
             except OSError as e:
                 if e.errno==errno.ESRCH:
                     running = False
+                    _log.debug('PID does not exist')
                 elif e.errno==errno.EPERM:
-                    pass # assume it's running as another user
+                    _log.debug("Can't say if PID exists or not")
                 else:
                     _log.exception("Testing PID %s", pid)
             fp.write('Running' if running else 'Dead')
+
+            if running:
+                fp.write('\t'+' '.join(ports))
         else:
             fp.write('Stopped')
 
         fp.write('\n')
+
+def syslist(conf, args):
+    SP.check_call([systemctl,
+                    '--user' if args.user else '--system',
+                    'list-units', 'procserv-*'])
 
 def addproc(conf, args):
     outdir = getgendir(user=args.user)
@@ -107,6 +126,82 @@ chdir = %(chdir)s
                    '--user' if args.user else '--system',
                    'daemon-reload'], shell=False)
 
+    if args.autostart:
+        SP.check_call([systemctl,
+                       '--user' if args.user else '--system',
+                       'start', 'procserv-%s.service'%args.name])
+    else:
+        sys.stdout.write("# systemctl start procserv-%s.service\n"%args.name)
+
+def delproc(conf, args):
+    from .conf import getconffiles, ConfigParser
+    for cfile in getconffiles(user=args.user):
+        _log.debug('Process %s', cfile)
+
+        with open(cfile) as F:
+            C = ConfigParser({'instance':'1'})
+            C.readfp(F)
+
+        if not C.has_section(args.name):
+            continue
+        if not C.getboolean(args.name, 'instance'):
+            continue
+
+        if not args.force and sys.stdin.isatty():
+            while True:
+                sys.stdout.write("Remove section '%s' from %s ? [yN]"%(args.name, cfile))
+                sys.stdout.flush()
+                L = sys.stdin.readline().strip().upper()
+                if L=='Y':
+                    break
+                elif L in ('N',''):
+                    sys.exit(1)
+                else:
+                    sys.stdout.write('\n')
+
+        if len(C.defaults())==1 and len(C.sections())==1:
+            _log.info('Removing empty file %s', cfile)
+            os.remove(cfile)
+        else:
+            C.remove_section(args.name)
+            C.remove_option('DEFAULT', 'instance')
+            _log.info("Removing section '%s' from file %s", args.name, cfile)
+            with open(cfile+'.tmp', 'w') as F:
+                C.write(F)
+            os.rename(cfile+'.tmp', cfile)
+
+    _log.info('Trigger systemd reload')
+    SP.check_call([systemctl,
+                   '--user' if args.user else '--system',
+                   'daemon-reload'], shell=False)
+
+    sys.stdout.write("# systemctl stop procserv-%s.service\n"%args.name)
+
+def writeprocs(conf, args):
+    opts = {
+        'rundir':getrundir(user=args.user),
+    }
+    _log.debug('Writing %s', args.out)
+    with open(args.out+'.tmp', 'w') as F:
+        for name in conf.sections():
+            opts['name'] = name
+            F.write("""
+console %(name)s {
+    master localhost;
+    type uds;
+    uds %(rundir)s/procserv-%(name)s/control;
+}
+"""%opts)
+
+    os.rename(args.out+'.tmp', args.out)
+
+    if args.reload:
+        _log.debug('Reloading conserver-server')
+        SP.check_call([systemctl,
+                    '--user' if args.user else '--system',
+                    'reload', 'conserver-server.service'], shell=False)
+    else:
+        sys.stdout.write('# systemctl reload conserver-server.service\n')
 
 def getargs():
     from argparse import ArgumentParser
@@ -115,21 +210,37 @@ def getargs():
                    help='Consider user config')
     P.add_argument('--system', dest='user', action='store_false',
                    help='Consider system config')
+    P.add_argument('-v','--verbose', action='count', default=0)
 
     SP = P.add_subparsers()
 
     S = SP.add_parser('status', help='List procServ instance state')
     S.set_defaults(func=status)
 
-    S = SP.add_parser('add', help='Create a new procServ instance state')
+    S = SP.add_parser('list', help='List procServ instances')
+    S.set_defaults(func=syslist)
+
+    S = SP.add_parser('add', help='Create a new procServ instance')
     S.add_argument('-C','--chdir', default=os.getcwd(), help='Run directory for instance')
     S.add_argument('-P','--port', help='telnet port')
     S.add_argument('-U','--user', dest='username')
     S.add_argument('-G','--group')
     S.add_argument('-f','--force', action='store_true', default=False)
+    S.add_argument('-A','--autostart',action='store_true', default=False,
+                   help='Automatically start after adding')
     S.add_argument('name', help='Instance name')
     S.add_argument('command', nargs='+', help='Command')
     S.set_defaults(func=addproc)
+
+    S = SP.add_parser('remove', help='Remove a procServ instance')
+    S.add_argument('-f','--force', action='store_true', default=False)
+    S.add_argument('name', help='Instance name')
+    S.set_defaults(func=delproc)
+
+    S = SP.add_parser('write-procs-cf', help='Write conserver config')
+    S.add_argument('-f','--out',default='/etc/conserver/procs.cf') 
+    S.add_argument('-R','--reload', action='store_true', default=False)
+    S.set_defaults(func=writeprocs)
 
     A = P.parse_args()
     if not hasattr(A, 'func'):
@@ -138,6 +249,7 @@ def getargs():
     return A
 
 def main(args):
-    logging.basicConfig(level=logging.DEBUG)
+    lvl = _levels[max(0, min(args.verbose, len(_levels)-1))]
+    logging.basicConfig(level=lvl)
     conf = getconf(user=args.user)
     args.func(conf, args)

--- a/procServUtils/shlex.py
+++ b/procServUtils/shlex.py
@@ -1,0 +1,304 @@
+"""A lexical analyzer class for simple shell-like syntaxes."""
+
+# Module and documentation by Eric S. Raymond, 21 Dec 1998
+# Input stacking and error message cleanup added by ESR, March 2000
+# push_source() and pop_source() made explicit by ESR, January 2001.
+# Posix compliance, split(), string arguments, and
+# iterator interface by Gustavo Niemeyer, April 2003.
+
+import os
+import re
+import sys
+from collections import deque
+
+from io import StringIO
+
+__all__ = ["shlex", "split", "quote"]
+
+class shlex:
+    "A lexical analyzer class for simple shell-like syntaxes."
+    def __init__(self, instream=None, infile=None, posix=False):
+        if isinstance(instream, str):
+            instream = StringIO(instream)
+        if instream is not None:
+            self.instream = instream
+            self.infile = infile
+        else:
+            self.instream = sys.stdin
+            self.infile = None
+        self.posix = posix
+        if posix:
+            self.eof = None
+        else:
+            self.eof = ''
+        self.commenters = '#'
+        self.wordchars = ('abcdfeghijklmnopqrstuvwxyz'
+                          'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_')
+        if self.posix:
+            self.wordchars += ('ßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
+                               'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ')
+        self.whitespace = ' \t\r\n'
+        self.whitespace_split = False
+        self.quotes = '\'"'
+        self.escape = '\\'
+        self.escapedquotes = '"'
+        self.state = ' '
+        self.pushback = deque()
+        self.lineno = 1
+        self.debug = 0
+        self.token = ''
+        self.filestack = deque()
+        self.source = None
+        if self.debug:
+            print('shlex: reading from %s, line %d' \
+                  % (self.instream, self.lineno))
+
+    def push_token(self, tok):
+        "Push a token onto the stack popped by the get_token method"
+        if self.debug >= 1:
+            print("shlex: pushing token " + repr(tok))
+        self.pushback.appendleft(tok)
+
+    def push_source(self, newstream, newfile=None):
+        "Push an input source onto the lexer's input source stack."
+        if isinstance(newstream, str):
+            newstream = StringIO(newstream)
+        self.filestack.appendleft((self.infile, self.instream, self.lineno))
+        self.infile = newfile
+        self.instream = newstream
+        self.lineno = 1
+        if self.debug:
+            if newfile is not None:
+                print('shlex: pushing to file %s' % (self.infile,))
+            else:
+                print('shlex: pushing to stream %s' % (self.instream,))
+
+    def pop_source(self):
+        "Pop the input source stack."
+        self.instream.close()
+        (self.infile, self.instream, self.lineno) = self.filestack.popleft()
+        if self.debug:
+            print('shlex: popping to %s, line %d' \
+                  % (self.instream, self.lineno))
+        self.state = ' '
+
+    def get_token(self):
+        "Get a token from the input stream (or from stack if it's nonempty)"
+        if self.pushback:
+            tok = self.pushback.popleft()
+            if self.debug >= 1:
+                print("shlex: popping token " + repr(tok))
+            return tok
+        # No pushback.  Get a token.
+        raw = self.read_token()
+        # Handle inclusions
+        if self.source is not None:
+            while raw == self.source:
+                spec = self.sourcehook(self.read_token())
+                if spec:
+                    (newfile, newstream) = spec
+                    self.push_source(newstream, newfile)
+                raw = self.get_token()
+        # Maybe we got EOF instead?
+        while raw == self.eof:
+            if not self.filestack:
+                return self.eof
+            else:
+                self.pop_source()
+                raw = self.get_token()
+        # Neither inclusion nor EOF
+        if self.debug >= 1:
+            if raw != self.eof:
+                print("shlex: token=" + repr(raw))
+            else:
+                print("shlex: token=EOF")
+        return raw
+
+    def read_token(self):
+        quoted = False
+        escapedstate = ' '
+        while True:
+            nextchar = self.instream.read(1)
+            if nextchar == '\n':
+                self.lineno = self.lineno + 1
+            if self.debug >= 3:
+                print("shlex: in state", repr(self.state), \
+                      "I see character:", repr(nextchar))
+            if self.state is None:
+                self.token = ''        # past end of file
+                break
+            elif self.state == ' ':
+                if not nextchar:
+                    self.state = None  # end of file
+                    break
+                elif nextchar in self.whitespace:
+                    if self.debug >= 2:
+                        print("shlex: I see whitespace in whitespace state")
+                    if self.token or (self.posix and quoted):
+                        break   # emit current token
+                    else:
+                        continue
+                elif nextchar in self.commenters:
+                    self.instream.readline()
+                    self.lineno = self.lineno + 1
+                elif self.posix and nextchar in self.escape:
+                    escapedstate = 'a'
+                    self.state = nextchar
+                elif nextchar in self.wordchars:
+                    self.token = nextchar
+                    self.state = 'a'
+                elif nextchar in self.quotes:
+                    if not self.posix:
+                        self.token = nextchar
+                    self.state = nextchar
+                elif self.whitespace_split:
+                    self.token = nextchar
+                    self.state = 'a'
+                else:
+                    self.token = nextchar
+                    if self.token or (self.posix and quoted):
+                        break   # emit current token
+                    else:
+                        continue
+            elif self.state in self.quotes:
+                quoted = True
+                if not nextchar:      # end of file
+                    if self.debug >= 2:
+                        print("shlex: I see EOF in quotes state")
+                    # XXX what error should be raised here?
+                    raise ValueError("No closing quotation")
+                if nextchar == self.state:
+                    if not self.posix:
+                        self.token = self.token + nextchar
+                        self.state = ' '
+                        break
+                    else:
+                        self.state = 'a'
+                elif self.posix and nextchar in self.escape and \
+                     self.state in self.escapedquotes:
+                    escapedstate = self.state
+                    self.state = nextchar
+                else:
+                    self.token = self.token + nextchar
+            elif self.state in self.escape:
+                if not nextchar:      # end of file
+                    if self.debug >= 2:
+                        print("shlex: I see EOF in escape state")
+                    # XXX what error should be raised here?
+                    raise ValueError("No escaped character")
+                # In posix shells, only the quote itself or the escape
+                # character may be escaped within quotes.
+                if escapedstate in self.quotes and \
+                   nextchar != self.state and nextchar != escapedstate:
+                    self.token = self.token + self.state
+                self.token = self.token + nextchar
+                self.state = escapedstate
+            elif self.state == 'a':
+                if not nextchar:
+                    self.state = None   # end of file
+                    break
+                elif nextchar in self.whitespace:
+                    if self.debug >= 2:
+                        print("shlex: I see whitespace in word state")
+                    self.state = ' '
+                    if self.token or (self.posix and quoted):
+                        break   # emit current token
+                    else:
+                        continue
+                elif nextchar in self.commenters:
+                    self.instream.readline()
+                    self.lineno = self.lineno + 1
+                    if self.posix:
+                        self.state = ' '
+                        if self.token or (self.posix and quoted):
+                            break   # emit current token
+                        else:
+                            continue
+                elif self.posix and nextchar in self.quotes:
+                    self.state = nextchar
+                elif self.posix and nextchar in self.escape:
+                    escapedstate = 'a'
+                    self.state = nextchar
+                elif nextchar in self.wordchars or nextchar in self.quotes \
+                    or self.whitespace_split:
+                    self.token = self.token + nextchar
+                else:
+                    self.pushback.appendleft(nextchar)
+                    if self.debug >= 2:
+                        print("shlex: I see punctuation in word state")
+                    self.state = ' '
+                    if self.token:
+                        break   # emit current token
+                    else:
+                        continue
+        result = self.token
+        self.token = ''
+        if self.posix and not quoted and result == '':
+            result = None
+        if self.debug > 1:
+            if result:
+                print("shlex: raw token=" + repr(result))
+            else:
+                print("shlex: raw token=EOF")
+        return result
+
+    def sourcehook(self, newfile):
+        "Hook called on a filename to be sourced."
+        if newfile[0] == '"':
+            newfile = newfile[1:-1]
+        # This implements cpp-like semantics for relative-path inclusion.
+        if isinstance(self.infile, str) and not os.path.isabs(newfile):
+            newfile = os.path.join(os.path.dirname(self.infile), newfile)
+        return (newfile, open(newfile, "r"))
+
+    def error_leader(self, infile=None, lineno=None):
+        "Emit a C-compiler-like, Emacs-friendly error-message leader."
+        if infile is None:
+            infile = self.infile
+        if lineno is None:
+            lineno = self.lineno
+        return "\"%s\", line %d: " % (infile, lineno)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        token = self.get_token()
+        if token == self.eof:
+            raise StopIteration
+        return token
+
+def split(s, comments=False, posix=True):
+    lex = shlex(s, posix=posix)
+    lex.whitespace_split = True
+    if not comments:
+        lex.commenters = ''
+    return list(lex)
+
+
+_find_unsafe = re.compile(r'[^\w@%+=:,./-]', re.ASCII).search
+
+def quote(s):
+    """Return a shell-escaped version of the string *s*."""
+    if not s:
+        return "''"
+    if _find_unsafe(s) is None:
+        return s
+
+    # use single quotes, and put single quotes into double quotes
+    # the string $'b is then quoted as '$'"'"'b'
+    return "'" + s.replace("'", "'\"'\"'") + "'"
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        lexer = shlex()
+    else:
+        file = sys.argv[1]
+        lexer = shlex(open(file), file)
+    while 1:
+        tt = lexer.get_token()
+        if tt:
+            print("Token: " + repr(tt))
+        else:
+            break

--- a/procServUtils/shlex.py
+++ b/procServUtils/shlex.py
@@ -1,17 +1,24 @@
 """A lexical analyzer class for simple shell-like syntaxes."""
 
+# This is a copy of shlex.py taken from 3.4.2 and adapted
+# for use with python 2.7 strings (not unicode).
+# As such it is licensed under the Python Software
+# Foundation license v2.
+
 # Module and documentation by Eric S. Raymond, 21 Dec 1998
 # Input stacking and error message cleanup added by ESR, March 2000
 # push_source() and pop_source() made explicit by ESR, January 2001.
 # Posix compliance, split(), string arguments, and
 # iterator interface by Gustavo Niemeyer, April 2003.
 
+from __future__ import print_function
+
 import os
 import re
 import sys
 from collections import deque
 
-from io import StringIO
+from cStringIO import StringIO
 
 __all__ = ["shlex", "split", "quote"]
 
@@ -34,9 +41,6 @@ class shlex:
         self.commenters = '#'
         self.wordchars = ('abcdfeghijklmnopqrstuvwxyz'
                           'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_')
-        if self.posix:
-            self.wordchars += ('ßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
-                               'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ')
         self.whitespace = ' \t\r\n'
         self.whitespace_split = False
         self.quotes = '\'"'
@@ -267,6 +271,7 @@ class shlex:
         if token == self.eof:
             raise StopIteration
         return token
+    next = __next__
 
 def split(s, comments=False, posix=True):
     lex = shlex(s, posix=posix)
@@ -276,7 +281,7 @@ def split(s, comments=False, posix=True):
     return list(lex)
 
 
-_find_unsafe = re.compile(r'[^\w@%+=:,./-]', re.ASCII).search
+_find_unsafe = re.compile(r'[^\w@%+=:,./-]').search
 
 def quote(s):
     """Return a shell-escaped version of the string *s*."""

--- a/procServUtils/telnet.py
+++ b/procServUtils/telnet.py
@@ -1,0 +1,56 @@
+
+import logging
+_log = logging.getLogger(__name__)
+
+import sys, os, errno
+from .conf import getrundir
+
+_levels = [
+    logging.WARN,
+    logging.INFO,
+    logging.DEBUG,
+]
+
+telnet = '/usr/bin/telnet'
+
+def getargs():
+    from argparse import ArgumentParser
+    P = ArgumentParser()
+    P.add_argument('--user', action='store_true', default=os.geteuid()!=0,
+                   help='Consider user config')
+    P.add_argument('--system', dest='user', action='store_false',
+                   help='Consider system config')
+    P.add_argument('-v','--verbose', action='count', default=0)
+    P.add_argument("proc", help='Name of instance to attach')
+    P.add_argument('extra', nargs='*', help='extra args for telnet')
+    return P.parse_args()
+
+def main(args):
+    lvl = _levels[max(0, min(args.verbose, len(_levels)-1))]
+    logging.basicConfig(level=lvl)
+
+    rundir = getrundir(user=args.user)
+
+    info = '%s/procserv-%s/info'%(rundir, args.proc)
+    try:
+        with open(info) as F:
+            for L in map(str.strip, F):
+                if not L.startswith('tcp:'):
+                    continue
+
+                _tcp, iface, port = L.split(':', 2)
+
+                args = [telnet, iface, port]+args.extra
+                _log.debug('exec: %s', ' '.join(args))
+
+                os.execv(telnet, args)
+                sys.exit(1) # never reached
+
+            sys.error('%s has no tcp control port')
+    except OSError as e:
+        if e.errno==errno.ENOENT:
+            _log.error('%s is not an active %s procServ', args.name, 'user' if args.user else 'system')
+        else:
+            _log.exception("Can't open %s"%info)
+
+    sys.exit(1)

--- a/prtelnet
+++ b/prtelnet
@@ -1,0 +1,4 @@
+#!/usr/bin/python3
+
+from procServUtils.telnet import getargs, main
+main(getargs())

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
     scripts = [
         'manage-procs',
         'procServ-launcher',
+        'prtelnet',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(
+    name='procServUtils',
+    description='Support scripts for procServ',
+    packages = ['procServUtils'],
+    scripts = [
+        'manage-procs',
+        'procServ-launcher',
+    ],
+)

--- a/systemd-procserv-generator-system
+++ b/systemd-procserv-generator-system
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+
+import sys
+
+from procServUtils import conf, generator
+generator.run(sys.argv[1], user=False)

--- a/systemd-procserv-generator-user
+++ b/systemd-procserv-generator-user
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+
+import sys
+
+from procServUtils import conf, generator
+generator.run(sys.argv[1], user=True)


### PR DESCRIPTION
systemd integration of procserv along the same lines as my sysv-rc-softioc.  With the adoption of systemd by both debian and redhat, I think this work might reasonably be included with procServ itself.  If this isn't desirable, I can maintain it as a separate package.


Provides some helpers for creating/maintaining procserv instances managed as systemd new-style daemons.

Locations:

* Configuration files defining instances. 

/etc/procServ.conf
/etc/procServ.d/*.conf

or

~/.config/procServ.conf
~/.config/procServ.d.*.conf

These contain blocks like:

```
[instancename]
command = /bin/bash
## optional
#chdir = /
#user = nobody
#group = nogroup
#port=0  # default to dynamic assignment
```

systemd generators generate unit files from this.

These can be managed by hand and/or with the 'manage-procs' CLI utility.

```
usage: manage-procs [-h] [--user] [--system] [-v]
                    {status,list,add,remove,write-procs-cf} ...

positional arguments:
  {status,list,add,remove,write-procs-cf}
    status              List procServ instance state
    list                List procServ instances
    add                 Create a new procServ instance
    remove              Remove a procServ instance
    write-procs-cf      Write conserver config

optional arguments:
  -h, --help            show this help message and exit
  --user                Consider user config
  --system              Consider system config
  -v, --verbose
```

Instances defined in /etc are managed by the global systemd instance.
Those in ~/.config are managed by this user's systemd instance.

In addition a script 'prtelnet' takes an instance name, looks up the port and exec 'telnet'.

An example conserver config is provided to go along with "manage-iocs write-procs-cf".

Two options for handling log files are provided: rsyslog and "manual".  The rsyslog option also includes logrotate.

This is intended to be a complete, integrated, solution.  However, several pieces are usable in isolation.  eg. handling of log files is independent of the config files and scripts described above except for the daemon name beginning with "procserv-".

I've include only rsyslog config as this is the default for debian 8.  I'd like to get syslog-ng config as well.

An open question for me is the suitability of depending on python 3 for the scripts.  At the moment they run with both 2.7 and 3.4.  Requiring >=3.4 would allow the embedded "copy" of shlex.py to be dropped.