### PR TITLE
run the child only once and exit the server

### DIFF
--- a/procServ.cc
+++ b/procServ.cc
@@ -208,6 +208,7 @@ int main(int argc,char * argv[])
     const size_t BUFLEN = 512;
     char buff[BUFLEN];
     std::string infofile;
+    bool firstRun;
 
     time(&procServStart);             // remember start time
     procservName = argv[0];
@@ -579,6 +580,7 @@ int main(int argc,char * argv[])
     strncat(infoMessage1, buff, INFO1LEN-strlen(infoMessage1)-1);
     snprintf(infoMessage2, INFO2LEN, "@@@ Child \"%s\" is SHUT DOWN" NL, childName);
 
+    firstRun = true;
     // Run here until something makes it die
     while ( ! shutdownServer )
     {
@@ -637,12 +639,15 @@ int main(int argc,char * argv[])
             // This call returns NULL if the process item lives
             if (processFactoryNeedsRestart())
             {
-                if (onlyOnce) {
+                if (onlyOnce && !firstRun) {
                   PRINTF("Onlyonce is set.. exiting\n");
                   shutdownServer = true;
                 } else {
                   npi= processFactory(childExec, childArgv);
                   if (npi) AddConnection(npi);
+                  if (firstRun) {
+                  	firstRun = false;
+                  }
                 }
             }
         } else if (-1 == ready) {             // Error

--- a/procServ.h
+++ b/procServ.h
@@ -37,6 +37,7 @@ extern bool   logPortLocal;
 extern bool   autoRestart;
 extern bool   waitForManualStart;
 extern volatile bool shutdownServer;
+extern volatile bool onlyOnce;
 extern bool   setCoreSize;
 extern char   *procservName;
 extern char   *childName;


### PR DESCRIPTION
First attempt to add an option (--once; -o) that makes the server exit if the child died (without any user interference).

Useful when system wide service manager (i.e. systemd) is used to start the procServ (and IOC) and one needs procServ to terminate if IOC was terminated. Service manager would then restart the service. Before or after the launch of procServ user is allowed to execute arbitrary tools.