### PR TITLE
fixed the systemd utils

### DIFF
--- a/procServUtils/conf.py
+++ b/procServUtils/conf.py
@@ -38,9 +38,9 @@ def getconffiles(user=False):
     if _testprefix:
         prefix = _testprefix
     elif user:
-        return '~/.config'
+        prefix = os.path.expanduser('~/.config')
     else:
-        return '/etc'
+        prefix = '/etc'
 
     files = map(os.path.expanduser, [
         prefix+'/procServ.conf',

--- a/procServUtils/generator.py
+++ b/procServUtils/generator.py
@@ -27,7 +27,7 @@ ConditionPathIsDirectory=%(chdir)s
     F.write("""
 [Service]
 Type=simple
-ExecStart=/usr/bin/procServ-launcher %(userarg)s %(name)s
+ExecStart=/usr/local/bin/procServ-launcher %(userarg)s %(name)s
 RuntimeDirectory=procserv-%(name)s
 StandardOutput=syslog
 StandardError=inherit
@@ -48,13 +48,13 @@ WantedBy=multi-user.target
 def run(outdir, user=False):
     conf = getconf(user=user)
 
-    wantsdir = os.path.join(outdir, 'multi-user.target.wants')
-    try:
-        os.makedirs(wantsdir)
-    except OSError as e:
-        if e.errno!=errno.EEXIST:
-            _log.exception('Creating directory "%s"', wantsdir)
-            raise
+    #wantsdir = os.path.join(outdir, 'multi-user.target.wants')
+    #try:
+    #    os.makedirs(wantsdir)
+    #except OSError as e:
+    #    if e.errno!=errno.EEXIST:
+    #        _log.exception('Creating directory "%s"', wantsdir)
+    #        raise
 
 
     for sect in conf.sections():
@@ -69,5 +69,5 @@ def run(outdir, user=False):
 
         os.rename(ofile+'.tmp', ofile)
         
-        os.symlink(ofile,
-                   os.path.join(wantsdir, service))
+        #os.symlink(ofile,
+        #           os.path.join(wantsdir, service))

--- a/procServUtils/launch.py
+++ b/procServUtils/launch.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from . import shlex
 
-procServ = '/usr/bin/procServ'
+procServ = '/usr/local/bin/procServ'
 
 def getargs():
     from argparse import ArgumentParser
@@ -57,13 +57,13 @@ def main(args):
         '--ignore','^D^C^]',
         '--chdir',chdir,
         '--info-file',os.path.join(rundir, 'procserv-%s'%name, 'info'), #/run/procserv-$NAME/info
-        '--port', 'unix:%s/procserv-%s/control'%(rundir,name),
+        '--port', port if port != "0" else 'unix:%s/procserv-%s/control'%(rundir,name),
     ]
 
     if args.debug>1:
         toexec.append('--debug')
 
-    toexec.append(port)
+    #toexec.append(port)
     toexec.extend(shlex.split(cmd))
 
     if args.debug>0:


### PR DESCRIPTION
Tested it under ubuntu server 16.04 LTS.

The scripts now actually create a service file in `~/.config/procServ.d/` or `/etc/procServ.d/` respectively, 
and register it as a service with the `systemctl enable` command rather than just copying them / linking them into the systemd directories. (`~/.config/systemd/user` or `/etc/systemd/system`)
this way, its easier to remove them again.

also, the behaviour on removing a service via the manage-procs script changed: if the service is still running, manage-procs now automatically stops it and then removes it...

~ William