### PR TITLE
Support for systemd environment variables

### DIFF
--- a/procServUtils/generator.py
+++ b/procServUtils/generator.py
@@ -35,14 +35,13 @@ ConditionPathIsDirectory=%(chdir)s
 [Service]
 Type=simple
 """%opts)
-    
+
     if conf.has_option(sect, 'env_file'):
         F.write('EnvironmentFile=%s\n'%conf.get(sect, 'env_file'))
-    
+
     if conf.has_option(sect, 'environment'):
         F.write('Environment=%s\n'%conf.get(sect, 'environment'))
-    
-    
+
     F.write("""\
 ExecStart=%(launcher)s %(userarg)s %(name)s
 RuntimeDirectory=procserv-%(name)s

--- a/procServUtils/generator.py
+++ b/procServUtils/generator.py
@@ -34,6 +34,16 @@ ConditionPathIsDirectory=%(chdir)s
     F.write("""
 [Service]
 Type=simple
+"""%opts)
+    
+    if conf.has_option(sect, 'env_file'):
+        F.write('EnvironmentFile=%s\n'%conf.get(sect, 'env_file'))
+    
+    if conf.has_option(sect, 'environment'):
+        F.write('Environment=%s\n'%conf.get(sect, 'environment'))
+    
+    
+    F.write("""\
 ExecStart=%(launcher)s %(userarg)s %(name)s
 RuntimeDirectory=procserv-%(name)s
 StandardOutput=syslog

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -118,8 +118,13 @@ def addproc(conf, args):
 
     _log.info("Writing: %s", cfile)
 
-    # ensure chdir is an absolute path
+    # ensure chdir and env_file are absolute paths
     args.chdir = os.path.abspath(os.path.join(os.getcwd(), args.chdir))
+    if args.env_file: 
+        args.env_file = os.path.abspath(os.path.join(os.getcwd(), args.env_file))
+        if not os.path.exists(args.env_file):
+            _log.exception('File not found: "%s"', args.env_file)
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), args.env_file)
 
     args.command = os.path.abspath(os.path.join(args.chdir, args.command))
 
@@ -139,6 +144,8 @@ chdir = %(chdir)s
         if args.username: F.write("user = %s\n"%args.username)
         if args.group: F.write("group = %s\n"%args.group)
         if args.port: F.write("port = %s\n"%args.port)
+        if args.environment: F.write("environment = %s\n"%' '.join(args.environment))
+        if args.env_file: F.write("env_file = %s\n"%args.env_file)
 
     os.rename(cfile+'.tmp', cfile)
 
@@ -267,6 +274,8 @@ def getargs(args=None):
     S.add_argument('-P','--port', help='telnet port')
     S.add_argument('-U','--user', dest='username')
     S.add_argument('-G','--group')
+    S.add_argument('-e','--environment', action='append', help='Add an environment variable')
+    S.add_argument('-E','--env-file', help='Environment file path')
     S.add_argument('-f','--force', action='store_true', default=False)
     S.add_argument('-A','--autostart',action='store_true', default=False,
                    help='Automatically start after adding')

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -144,7 +144,9 @@ chdir = %(chdir)s
         if args.username: F.write("user = %s\n"%args.username)
         if args.group: F.write("group = %s\n"%args.group)
         if args.port: F.write("port = %s\n"%args.port)
-        if args.environment: F.write("environment = %s\n"%' '.join(args.environment))
+        if args.environment:
+            env_to_string = ' '.join("\"%s\""%e for e in args.environment)
+            F.write("environment = %s\n"%env_to_string)
         if args.env_file: F.write("env_file = %s\n"%args.env_file)
 
     os.rename(cfile+'.tmp', cfile)

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -123,8 +123,8 @@ def addproc(conf, args):
     if args.env_file:
         args.env_file = os.path.abspath(os.path.join(os.getcwd(), args.env_file))
         if not os.path.exists(args.env_file):
-            _log.exception('File not found: "%s"', args.env_file)
-            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), args.env_file)
+            _log.error('File not found: "%s"', args.env_file)
+            sys.exit(1)
 
     args.command = os.path.abspath(os.path.join(args.chdir, args.command))
 

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -120,7 +120,7 @@ def addproc(conf, args):
 
     # ensure chdir and env_file are absolute paths
     args.chdir = os.path.abspath(os.path.join(os.getcwd(), args.chdir))
-    if args.env_file: 
+    if args.env_file:
         args.env_file = os.path.abspath(os.path.join(os.getcwd(), args.env_file))
         if not os.path.exists(args.env_file):
             _log.exception('File not found: "%s"', args.env_file)


### PR DESCRIPTION
I found a way to solve #31 . I added two optional arguments to the ``manage-procs add`` command to set the systemd service file ``Environment`` and ``EnvironmentFile`` tags. Using these options one can execute an EPICS startup command with environment variables as parameters.

Usage example:
```bash
manage-procs add -E my_env_file example_service st.cmd
```
where ``my_env_file`` looks like:
```bash
FOO=foo
BAR=bar
```
or:
```bash
manage-procs add -e "FOO=foo" -e "BAR=bar" example_service st.cmd
```


Let me know if this can be merged.