### PR TITLE
procServUtils autocomplete and new commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ jobs:
         - os: linux
           language: python
           python: 2.7
-          install: pip install nose
+          install: pip install nose argcomplete termcolor tabulate
           script: python -m nose procServUtils
         - os: linux
           language: python
           python: 3.6
-          install: pip install nose
+          install: pip install nose argcomplete termcolor tabulate
           script: python -m nose procServUtils

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ start and stop configured procServ instances,
 generate lists of the instances known on the current host
 and report their status.
 
-For more details, check the manpage and use the script's `-h` option.
+For more details, see its [README](procServUtils/README.md) or check the manpage and use the script's `-h` option.
 
 For older systems using SysV-style rc scripts, you can look at the
 [Debian packaging](http://epics.nsls2.bnl.gov/debian/) or

--- a/manage-procs
+++ b/manage-procs
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# PYTHON_ARGCOMPLETE_OK
 
 from procServUtils.manage import getargs, main
 main(getargs())

--- a/procServUtils/README.md
+++ b/procServUtils/README.md
@@ -7,11 +7,11 @@ See below for the available commands.
 ## Installation
 
 Python prerequisites:
-```
+```bash
 sudo pip install tabulate termcolor argcomplete
 ```
 Activate global arcomplete completion:
-```
+```bash
 sudo activate-global-python-argcomplete 
 ```
 Then proceed to install procServ with the `--with-systemd-utils` configuration
@@ -25,9 +25,10 @@ See `manage-procs --help` for all the commands.
 
 All the `manage-procs` commands support one option to specify the destination of the service:
 
-- `manage-procs --system` will manage system-wide services. This is the default options
+-   `manage-procs --system` will manage system-wide services. This is the default options
 when running as root.
-- `manage-procs --user` will manage user-level services. It is the equivalent 
+
+-   `manage-procs --user` will manage user-level services. It is the equivalent 
 of `systemctl --user`. This is the default when running as a non-privileged user.
 
 **NOTE:** Not all linux distributions support user level systemd (eg: Centos 7). In those cases you should always use `--system`.
@@ -35,7 +36,7 @@ of `systemctl --user`. This is the default when running as a non-privileged user
 ### Add a service
 
 Let's add a service:
-```
+```bash
 manage-procs add service_name some_command [command_args...]
 ```
 This will install a new service called `service_name` which will run the specified command
@@ -43,32 +44,32 @@ with its args.
 
 With the optional arguments one can specify the working directory, the user
 running the process and also add some environment variables. For example:
-```
+```bash
 manage-procs add -C /path/to/some_folder -U user_name -G user_group -e "FOO=foo" -e "BAR=bar" service_name some_command [command_args...]
 ```
 Alternatively one can write an environment file like:
-```
+```bash
 FOO=foo
 BAR=bar
 ```
 And run:
-```
+```bash
 manage-procs add -C /path/to/some_folder -U user_name -G user_group -E /path/to/env_file service_name some_command [command_args...]
 ```
 See `manage-procs add -h` for all the options.
 
 ### List services
-```
+```bash
 manage-procs status
 ```
 will list all the services installed with `manage-procs add` and their status.
-```
+```bash
 manage-procs list
 ```
 will show the underlying systemd services.
 
 ### Start, stop, restart service exection
-```
+```bash
 manage-procs start service_name
 manage-procs stop service_name
 manage-procs restart service_name
@@ -76,23 +77,23 @@ manage-procs restart service_name
 
 ### Remove or rename a service
 To uninstall a service:
-```
+```bash
 manage-procs remove service_name
 ```
 To rename a service:
-```
+```bash
 manage-procs rename service_name
 ```
 
 ### Attach to a service
 `procServ` enables the user to see the output of the inner command and, eventually, interact with it through a telent port or a domain socket. 
-```
+```bash
 manage-procs attach service_name
 ```
 This will automatically open the right port for the desired service.
 
 ### Open service log files
 All the output of the service is saved to the systemd log files. To open them run:
-```
+```bash
 manage-procs logs [--follow] service_name
 ```

--- a/procServUtils/README.md
+++ b/procServUtils/README.md
@@ -1,0 +1,98 @@
+# procServUtils
+
+`manage-procs` is a script to run procServ instances as systemd services.
+It allows to completely manage the service with its command line interface.
+See below for the available commands.
+
+## Installation
+
+Python prerequisites:
+```
+sudo pip install tabulate termcolor argcomplete
+```
+Activate global arcomplete completion:
+```
+sudo activate-global-python-argcomplete 
+```
+Then proceed to install procServ with the `--with-systemd-utils` configuration
+option.
+
+## Using manage-procs
+
+See `manage-procs --help` for all the commands.
+
+### User or system services
+
+All the `manage-procs` support one option to specify the destination of the service:
+
+- `manage-procs --system` will manage system-wide services. This is the default options
+when running as root.
+- `manage-procs --user` will manage user-level services. It is the equivalent 
+of `systemctl --user`. This is the default when running as a non-privileged user.
+
+**NOTE:** Not all linux distributions support user level systemd (eg: Centos 7). In those cases you should always use `--system`.
+
+### Add a service
+
+Let's add a service:
+```
+manage-procs add service_name some_command [command_args...]
+```
+This will install a new service called `service_name` which will run the specified command
+with its args.
+
+With the optional arguments one can specify the working directory, the user
+running the process and also add some environment variables. For example:
+```
+manage-procs add -C /path/to/some_folder -U user_name -G user_group -e "FOO=foo" -e "BAR=bar" service_name some_command [command_args...]
+```
+Alternatively one can write an environment file like:
+```
+FOO=foo
+BAR=bar
+```
+And run:
+```
+manage-procs add -C /path/to/some_folder -U user_name -G user_group -E /path/to/env_file service_name some_command [command_args...]
+```
+See `manage-procs add -h` for all the options.
+
+### List services
+```
+manage-procs status
+```
+will list all the services installed with `manage-procs add` and their status.
+```
+manage-procs list
+```
+will show the underlying systemd services.
+
+### Start, stop, restart service exection
+```
+manage-procs start service_name
+manage-procs stop service_name
+manage-procs restart service_name
+```
+
+### Remove or rename a service
+To uninstall a service:
+```
+manage-procs remove service_name
+```
+To rename a service:
+```
+manage-procs rename service_name
+```
+
+### Attach to a service
+`procServ` enables the user to see the output of the inner command and, eventually, interact with it through a telent port or a domain socket. 
+```
+manage-procs attach service_name
+```
+This will automatically open the right port for the desired service.
+
+### Open service log files
+All the output of the service is saved to the systemd log files. To open them run:
+```
+manage-procs logs  [--follow] service_name
+```

--- a/procServUtils/README.md
+++ b/procServUtils/README.md
@@ -82,7 +82,7 @@ manage-procs remove service_name
 ```
 To rename a service:
 ```bash
-manage-procs rename service_name
+manage-procs rename service_name new_service_name
 ```
 
 ### Attach to a service

--- a/procServUtils/README.md
+++ b/procServUtils/README.md
@@ -120,6 +120,8 @@ To rename a service:
 manage-procs rename service_name new_service_name
 ```
 
+Note that this command will stop the service if it's running.
+
 ### Attach to a service
 
 `procServ` enables the user to see the output of the inner command and, eventually, interact with it through a telent port or a domain socket.

--- a/procServUtils/README.md
+++ b/procServUtils/README.md
@@ -23,7 +23,7 @@ See `manage-procs --help` for all the commands.
 
 ### User or system services
 
-All the `manage-procs` support one option to specify the destination of the service:
+All the `manage-procs` commands support one option to specify the destination of the service:
 
 - `manage-procs --system` will manage system-wide services. This is the default options
 when running as root.
@@ -94,5 +94,5 @@ This will automatically open the right port for the desired service.
 ### Open service log files
 All the output of the service is saved to the systemd log files. To open them run:
 ```
-manage-procs logs  [--follow] service_name
+manage-procs logs [--follow] service_name
 ```

--- a/procServUtils/README.md
+++ b/procServUtils/README.md
@@ -4,18 +4,31 @@
 It allows to completely manage the service with its command line interface.
 See below for the available commands.
 
-## Installation
+## Installation from source
 
 Python prerequisites:
+
 ```bash
 sudo pip install tabulate termcolor argcomplete
 ```
-Activate global arcomplete completion:
+
+Then proceed to build and install procServ with the `--with-systemd-utils` configuration option. For example:
+
 ```bash
-sudo activate-global-python-argcomplete 
+cd procserv
+make
+./configure --disable-doc --with-systemd-utils
+make
+sudo make install
 ```
-Then proceed to install procServ with the `--with-systemd-utils` configuration
-option.
+
+**[OPTIONAL]** If you want to activate bash autocompletion run the following command:
+
+```bash
+sudo activate-global-python-argcomplete
+```
+
+This will activate global argcomplete completion. See [argcomplete documentation](https://pypi.org/project/argcomplete/#activating-global-completion) for more details.
 
 ## Using manage-procs
 
@@ -25,50 +38,68 @@ See `manage-procs --help` for all the commands.
 
 All the `manage-procs` commands support one option to specify the destination of the service:
 
--   `manage-procs --system` will manage system-wide services. This is the default options
-when running as root.
+- `manage-procs --system` will manage system-wide services. This is the default options when running as root.
 
--   `manage-procs --user` will manage user-level services. It is the equivalent 
-of `systemctl --user`. This is the default when running as a non-privileged user.
+- `manage-procs --user` will manage user-level services. It is the equivalent
+  of `systemctl --user`. This is the default when running as a non-privileged user.
 
 **NOTE:** Not all linux distributions support user level systemd (eg: Centos 7). In those cases you should always use `--system`.
 
 ### Add a service
 
 Let's add a service:
+
 ```bash
 manage-procs add service_name some_command [command_args...]
 ```
+
 This will install a new service called `service_name` which will run the specified command
 with its args.
 
 With the optional arguments one can specify the working directory, the user
 running the process and also add some environment variables. For example:
+
 ```bash
-manage-procs add -C /path/to/some_folder -U user_name -G user_group -e "FOO=foo" -e "BAR=bar" service_name some_command [command_args...]
+manage-procs add -C /path/to/some_folder \
+                 -U user_name -G user_group \
+                 -e "FOO=foo" -e "BAR=bar" \
+                 service_name some_command [command_args...]
 ```
+
 Alternatively one can write an environment file like:
+
 ```bash
 FOO=foo
 BAR=bar
 ```
+
 And run:
+
 ```bash
-manage-procs add -C /path/to/some_folder -U user_name -G user_group -E /path/to/env_file service_name some_command [command_args...]
+manage-procs add -C /path/to/some_folder \
+                 -U user_name -G user_group \
+                 -E /path/to/env_file \
+                 service_name some_command [command_args...]
 ```
+
 See `manage-procs add -h` for all the options.
 
 ### List services
+
 ```bash
 manage-procs status
 ```
+
 will list all the services installed with `manage-procs add` and their status.
+
 ```bash
 manage-procs list
 ```
+
 will show the underlying systemd services.
 
 ### Start, stop, restart service exection
+
 ```bash
 manage-procs start service_name
 manage-procs stop service_name
@@ -76,24 +107,33 @@ manage-procs restart service_name
 ```
 
 ### Remove or rename a service
+
 To uninstall a service:
+
 ```bash
 manage-procs remove service_name
 ```
+
 To rename a service:
+
 ```bash
 manage-procs rename service_name new_service_name
 ```
 
 ### Attach to a service
-`procServ` enables the user to see the output of the inner command and, eventually, interact with it through a telent port or a domain socket. 
+
+`procServ` enables the user to see the output of the inner command and, eventually, interact with it through a telent port or a domain socket.
+
 ```bash
 manage-procs attach service_name
 ```
+
 This will automatically open the right port for the desired service.
 
 ### Open service log files
+
 All the output of the service is saved to the systemd log files. To open them run:
+
 ```bash
 manage-procs logs [--follow] service_name
 ```

--- a/procServUtils/conf.py
+++ b/procServUtils/conf.py
@@ -2,7 +2,7 @@
 import logging
 _log = logging.getLogger(__name__)
 
-import os
+import os, sys, errno
 from functools import reduce
 from glob import glob
 
@@ -52,6 +52,28 @@ def getconffiles(user=False):
     # map(glob) produces a list of lists
     # reduce by concatination into a single list
     return reduce(list.__add__, map(glob, files), [])
+
+def addconf(name, conf, user=False, force=False):
+    outdir = getgendir(user)
+    cfile = os.path.join(outdir, '%s.conf'%name)
+
+    if os.path.exists(cfile) and not force:
+        _log.error("Instance already exists @ %s", cfile)
+        sys.exit(1)
+
+    try:
+        os.makedirs(outdir)
+    except OSError as e:
+        if e.errno!=errno.EEXIST:
+            _log.exception('Creating directory "%s"', outdir)
+            raise
+
+    _log.info("Writing: %s", cfile)
+    with open(cfile, 'w') as F:
+        conf.write(F)
+
+def delconf(name):
+    pass
 
 _defaults = {
     'user':'nobody',

--- a/procServUtils/conf.py
+++ b/procServUtils/conf.py
@@ -72,9 +72,6 @@ def addconf(name, conf, user=False, force=False):
     with open(cfile, 'w') as F:
         conf.write(F)
 
-def delconf(name):
-    pass
-
 _defaults = {
     'user':'nobody',
     'group':'nogroup',

--- a/procServUtils/fallbacks.py
+++ b/procServUtils/fallbacks.py
@@ -1,0 +1,19 @@
+"""
+Fallback functions when termcolor or tabulate packes are not available
+"""
+
+
+def colored(s, *args, **kwargs):
+    return s
+
+
+def tabulate(table, headers, **kwargs):
+    s = ""
+    for header in headers:
+        s += "%s  " % header.strip()
+    s += "\n"
+    for line in table:
+        for elem in line:
+            s += "%s  " % elem.strip()
+        s += "\n"
+    return s[:-1]

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -251,9 +251,12 @@ console %(name)s {
     else:
         sys.stdout.write('# systemctl %s reload conserver-server.service\n'%argusersys)
 
+def instances_completer(**kwargs):
+    return getconf(user=False).sections() + getconf(user=True).sections()
+
 def getargs(args=None):
     from argparse import ArgumentParser, REMAINDER
-    import argcomplete
+    from argcomplete import autocomplete
     P = ArgumentParser()
     P.add_argument('--user', action='store_true', default=os.geteuid()!=0,
                    help='Consider user config')
@@ -287,7 +290,7 @@ def getargs(args=None):
 
     S = SP.add_parser('remove', help='Remove a procServ instance')
     S.add_argument('-f','--force', action='store_true', default=False)
-    S.add_argument('name', help='Instance name')
+    S.add_argument('name', help='Instance name').completer = instances_completer
     S.set_defaults(func=delproc)
 
     S = SP.add_parser('write-procs-cf', help='Write conserver config')
@@ -296,19 +299,19 @@ def getargs(args=None):
     S.set_defaults(func=writeprocs)
 
     S = SP.add_parser('start', help='Start a procServ instance')
-    S.add_argument('name', help='Instance name')
+    S.add_argument('name', help='Instance name').completer = instances_completer
     S.set_defaults(func=startproc)
 
     S = SP.add_parser('stop', help='Stop a procServ instance')
-    S.add_argument('name', help='Instance name')
+    S.add_argument('name', help='Instance name').completer = instances_completer
     S.set_defaults(func=stopproc)
 
     S = SP.add_parser('attach', help='Attach to a procServ instance')
-    S.add_argument("name", help='Instance name')
+    S.add_argument("name", help='Instance name').completer = instances_completer
     S.add_argument('extra', nargs=REMAINDER, help='extra args for telnet')
     S.set_defaults(func=attachproc)
 
-    argcomplete.autocomplete(P)
+    autocomplete(P)
     A = P.parse_args(args=args)
     if not hasattr(A, 'func'):
         P.print_help()

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -224,24 +224,13 @@ def delproc(conf, args):
     stopproc(conf, args)
 
     _log.info("Disabling service procserv-%s.service", args.name)
-    SP.check_call([systemctl,
+    SP.call([systemctl,
                    '--user' if args.user else '--system',
                    'disable',
                    "procserv-%s.service"%args.name])
 
     _log.info("Resetting service procserv-%s.service", args.name)
-    occurences = 0
-    check_service = SP.Popen([systemctl,
-                '--user' if args.user else '--system',
-                'list-units',
-                '--all',
-                'procserv-%s.service'%args.name], stdout=SP.PIPE)
-    output = check_service.communicate()[0].split('\n')
-    for row in output:
-        if 'loaded units listed' in row:
-            occurences = int(row[0])
-    if occurences != 0:
-        SP.check_call([systemctl,
+    SP.call([systemctl,
                     '--user' if args.user else '--system',
                     'reset-failed', 
                     'procserv-%s.service'%args.name])

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -235,10 +235,11 @@ def delproc(conf, args):
                    "procserv-%s.service"%args.name])
 
     _log.info("Resetting service procserv-%s.service", args.name)
+    devnull = open(os.devnull, 'w')
     SP.call([systemctl,
                     '--user' if args.user else '--system',
                     'reset-failed',
-                    'procserv-%s.service'%args.name], stderr=SP.DEVNULL)
+                    'procserv-%s.service'%args.name], stderr=devnull)
 
     _log.info('Triggering systemd reload')
     SP.check_call([systemctl,

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -229,7 +229,7 @@ def delproc(conf, args):
     stopproc(conf, args)
 
     _log.info("Disabling service procserv-%s.service", args.name)
-    SP.call([systemctl,
+    SP.check_call([systemctl,
                    '--user' if args.user else '--system',
                    'disable',
                    "procserv-%s.service"%args.name])

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -5,7 +5,7 @@ _log = logging.getLogger(__name__)
 import sys, os, errno
 import subprocess as SP
 
-from .conf import getconf, getrundir, getgendir, ConfigParser, addconf, delconf
+from .conf import getconf, getrundir, getgendir, ConfigParser, addconf, getconffiles
 
 try:
     import shlex
@@ -185,8 +185,7 @@ def addproc(conf, args):
 
 def delproc(conf, args):
     check_req(conf, args)
-        
-    from .conf import getconffiles, ConfigParser
+    
     for cfile in getconffiles(user=args.user):
         _log.debug('delproc processing %s', cfile)
 

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -91,6 +91,12 @@ def stopproc(conf, args):
             '--user' if args.user else '--system',
             'stop', 'procserv-%s.service'%args.name])
 
+def resetfailedproc(conf, args):
+    _log.info("Resetting service procserv-%s.service", args.name)
+    SP.call([systemctl,
+            '--user' if args.user else '--system',
+            'reset-failed', 'procserv-%s.service'%args.name])
+
 def restartproc(conf, args):
     _log.info("Restarting service procserv-%s.service", args.name)
     SP.call([systemctl,
@@ -327,6 +333,10 @@ def getargs(args=None):
     S = SP.add_parser('stop', help='Stop a procServ instance')
     S.add_argument('name', help='Instance name').completer = instances_completer
     S.set_defaults(func=stopproc)
+
+    S = SP.add_parser('reset-failed', help='Reset a failed procServ instance')
+    S.add_argument('name', help='Instance name').completer = instances_completer
+    S.set_defaults(func=resetfailedproc)
 
     S = SP.add_parser('restart', help='Restart a procServ instance')
     S.add_argument('name', help='Instance name').completer = instances_completer

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -253,6 +253,7 @@ console %(name)s {
 
 def getargs(args=None):
     from argparse import ArgumentParser, REMAINDER
+    import argcomplete
     P = ArgumentParser()
     P.add_argument('--user', action='store_true', default=os.geteuid()!=0,
                    help='Consider user config')
@@ -307,6 +308,7 @@ def getargs(args=None):
     S.add_argument('extra', nargs=REMAINDER, help='extra args for telnet')
     S.set_defaults(func=attachproc)
 
+    argcomplete.autocomplete(P)
     A = P.parse_args(args=args)
     if not hasattr(A, 'func'):
         P.print_help()

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -240,6 +240,9 @@ def renameproc(conf, args):
     from .generator import run
 
     # copy settings from previous conf
+    if args.name not in conf.sections():
+        _log.error('Unknown process: "%s"', args.name)
+        sys.exit(1)
     items = conf.items(args.name)
     new_conf = ConfigParser()
     new_conf.add_section(args.new_name)

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -27,9 +27,16 @@ def check_req(conf, args):
         sys.exit(1)
 
 def status(conf, args, fp=None):
-    from tabulate import tabulate
-    from termcolor import colored
+    try:
+        from tabulate import tabulate
+    except ImportError:
+        from .fallbacks import tabulate
     
+    try:
+        from termcolor import colored
+    except ImportError:
+        from .fallbacks import colored
+
     rundir=getrundir(user=args.user)
     fp = fp or sys.stdout
 
@@ -323,7 +330,7 @@ def instances_completer(**kwargs):
 
 def getargs(args=None):
     from argparse import ArgumentParser, REMAINDER
-    from argcomplete import autocomplete
+    
     P = ArgumentParser()
     P.add_argument('--user', action='store_true', default=os.geteuid()!=0,
                    help='Consider user config')
@@ -395,7 +402,12 @@ def getargs(args=None):
     S.add_argument('extra', nargs=REMAINDER, help='extra args for telnet')
     S.set_defaults(func=attachproc)
 
-    autocomplete(P)
+    try:
+        from argcomplete import autocomplete
+        autocomplete(P)
+    except ImportError:
+        pass
+
     A = P.parse_args(args=args)
     if not hasattr(A, 'func'):
         P.print_help()

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -38,7 +38,7 @@ def status(conf, args, fp=None):
         if not conf.getboolean(name, 'instance'):
             continue
         instance = ['%s '%name]
-        
+
         pid = None
         ports = []
         infoname = os.path.join(rundir, 'procserv-%s'%name, 'info')
@@ -80,7 +80,7 @@ def status(conf, args, fp=None):
             instance.append(colored('Stopped', 'red'))
         
         table.append(instance)
-    
+
     # Print results table
     headers = ['PROCESS', 'STATUS', 'PORT']
     fp.write(tabulate(sorted(table), headers=headers, tablefmt="github")+ '\n')

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -31,7 +31,7 @@ def status(conf, args, fp=None):
         from tabulate import tabulate
     except ImportError:
         from .fallbacks import tabulate
-    
+
     try:
         from termcolor import colored
     except ImportError:
@@ -85,7 +85,7 @@ def status(conf, args, fp=None):
                 instance.append(' '.join(ports))
         else:
             instance.append(colored('Stopped', 'red'))
-        
+
         table.append(instance)
 
     # Print results table
@@ -177,7 +177,7 @@ def addproc(conf, args):
     SP.check_call([systemctl,
                    argusersys,
                    'daemon-reload'], shell=False)
-    
+
     SP.check_call([systemctl,
                    argusersys,
                    'enable',
@@ -282,7 +282,7 @@ def renameproc(conf, args):
     SP.check_call([systemctl,
                    argusersys,
                    'daemon-reload'], shell=False)
-    
+
     SP.check_call([systemctl,
                    argusersys,
                    'enable',
@@ -329,7 +329,7 @@ def instances_completer(**kwargs):
 
 def getargs(args=None):
     from argparse import ArgumentParser, REMAINDER
-    
+
     P = ArgumentParser()
     P.add_argument('--user', action='store_true', default=os.geteuid()!=0,
                    help='Consider user config')
@@ -375,7 +375,7 @@ def getargs(args=None):
     S.set_defaults(func=renameproc)
 
     S = SP.add_parser('write-procs-cf', help='Write conserver config')
-    S.add_argument('-f','--out',default='/etc/conserver/procs.cf') 
+    S.add_argument('-f','--out',default='/etc/conserver/procs.cf')
     S.add_argument('-R','--reload', action='store_true', default=False)
     S.set_defaults(func=writeprocs)
 

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -173,15 +173,15 @@ def addproc(conf, args):
 
     # register systemd service
     argusersys = '--user' if args.user else '--system'
-    SP.check_call([systemctl,
-                   argusersys,
-                   'enable',
-                   "%s/procserv-%s.service"%(outdir, conf_name)])
-
     _log.info('Trigger systemd reload')
     SP.check_call([systemctl,
                    argusersys,
                    'daemon-reload'], shell=False)
+    
+    SP.check_call([systemctl,
+                   argusersys,
+                   'enable',
+                   "%s/procserv-%s.service"%(outdir, conf_name)])
 
     if args.autostart:
         startproc(conf, args)
@@ -237,9 +237,8 @@ def delproc(conf, args):
     _log.info("Resetting service procserv-%s.service", args.name)
     SP.call([systemctl,
                     '--user' if args.user else '--system',
-                    '--quiet',
                     'reset-failed',
-                    'procserv-%s.service'%args.name])
+                    'procserv-%s.service'%args.name], stderr=SP.DEVNULL)
 
     _log.info('Triggering systemd reload')
     SP.check_call([systemctl,
@@ -279,15 +278,15 @@ def renameproc(conf, args):
 
     # register systemd service
     argusersys = '--user' if args.user else '--system'
-    SP.check_call([systemctl,
-                   argusersys,
-                   'enable',
-                   "%s/procserv-%s.service"%(outdir, args.new_name)])
-
     _log.info('Trigger systemd reload')
     SP.check_call([systemctl,
                    argusersys,
                    'daemon-reload'], shell=False)
+    
+    SP.check_call([systemctl,
+                   argusersys,
+                   'enable',
+                   "%s/procserv-%s.service"%(outdir, args.new_name)])
 
     if args.autostart:
         args.name = args.new_name

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -235,8 +235,8 @@ def delproc(conf, args):
                    "procserv-%s.service"%args.name])
 
     _log.info("Resetting service procserv-%s.service", args.name)
-    devnull = open(os.devnull, 'w')
-    SP.call([systemctl,
+    with open(os.devnull, 'w') as devnull:
+        SP.call([systemctl,
                     '--user' if args.user else '--system',
                     'reset-failed',
                     'procserv-%s.service'%args.name], stderr=devnull)

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -252,7 +252,10 @@ console %(name)s {
         sys.stdout.write('# systemctl %s reload conserver-server.service\n'%argusersys)
 
 def instances_completer(**kwargs):
-    return getconf(user=False).sections() + getconf(user=True).sections()
+    user = True
+    if 'parsed_args' in kwargs:
+        user = kwargs['parsed_args'].user
+    return getconf(user=user).sections()
 
 def getargs(args=None):
     from argparse import ArgumentParser, REMAINDER

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -257,6 +257,19 @@ def delproc(conf, args):
 
 def renameproc(conf, args):
     check_req(conf, args)
+    
+    if not args.force and sys.stdin.isatty():
+        while True:
+            sys.stdout.write("This will stop the service '%s' if it's running. Continue? [yN] "%(args.name))
+            sys.stdout.flush()
+            L = sys.stdin.readline().strip().upper()
+            if L=='Y':
+                break
+            elif L in ('N',''):
+                sys.exit(1)
+            else:
+                sys.stdout.write('\n')
+
     from .generator import run
 
     # copy settings from previous conf
@@ -367,7 +380,7 @@ def getargs(args=None):
     S.add_argument('name', help='Instance name').completer = instances_completer
     S.set_defaults(func=delproc)
 
-    S = SP.add_parser('rename', help='Rename a procServ instance')
+    S = SP.add_parser('rename', help='Rename a procServ instance. The instance will be stopped.')
     S.add_argument('-f','--force', action='store_true', default=False)
     S.add_argument('-A','--autostart',action='store_true', default=False,
                    help='Automatically start after renaming')

--- a/procServUtils/test/test_manage.py
+++ b/procServUtils/test/test_manage.py
@@ -98,21 +98,20 @@ group = controls
         with TestDir() as t:
             main(getargs(['add', '-C', '/somedir', '-U', 'foo', '-G', 'bar', \
                           'firstname', '--', '/bin/sh', '-c', 'blah']), test=True)
-            main(getargs(['rename', 'firstname', 'secondname']), test=True)
+            main(getargs(['rename', '-f', 'firstname', 'secondname']), test=True)
 
             confname = t.dir+'/procServ.d/secondname.conf'
 
             self.assertTrue(os.path.isfile(confname))
             with open(confname, 'r') as F:
-                content = F.read()
+                content = F.readlines()
 
-            self.assertEqual(content,
-"""[secondname]
-user = foo
-group = bar
-chdir = /somedir
-port = 0
-instance = 1
-command = /bin/sh -c blah
-
-""")
+            self.assertIn("[secondname]\n", content)
+            self.assertIn("user = foo\n", content)
+            self.assertIn("group = bar\n", content)
+            self.assertIn("chdir = /somedir\n", content)
+            self.assertIn("port = 0\n", content)
+            self.assertIn("instance = 1\n", content)
+            self.assertIn("command = /bin/sh -c blah\n", content)
+            self.assertIn("\n", content)
+            self.assertEqual(len(content), 8)

--- a/procServUtils/test/test_manage.py
+++ b/procServUtils/test/test_manage.py
@@ -38,7 +38,7 @@ chdir = /somedir
             with open(confname, 'r') as F:
                 content = F.read()
 
-            self.assertEqual(content, 
+            self.assertEqual(content,
 """[other]
 command = /bin/sh -c blah
 chdir = /somedir

--- a/procServUtils/test/test_manage.py
+++ b/procServUtils/test/test_manage.py
@@ -93,3 +93,26 @@ group = controls
 
             self.assertTrue(os.path.isfile(confname))
             self.assertTrue(os.path.isfile(t.dir+'/procServ.d/other.conf'))
+
+    def test_rename(self):
+        with TestDir() as t:
+            main(getargs(['add', '-C', '/somedir', '-U', 'foo', '-G', 'bar', \
+                          'firstname', '--', '/bin/sh', '-c', 'blah']), test=True)
+            main(getargs(['rename', 'firstname', 'secondname']), test=True)
+
+            confname = t.dir+'/procServ.d/secondname.conf'
+
+            self.assertTrue(os.path.isfile(confname))
+            with open(confname, 'r') as F:
+                content = F.read()
+
+            self.assertEqual(content,
+"""[secondname]
+user = foo
+group = bar
+chdir = /somedir
+port = 0
+instance = 1
+command = /bin/sh -c blah
+
+""")

--- a/procServUtils/test/test_manage.py
+++ b/procServUtils/test/test_manage.py
@@ -19,10 +19,11 @@ class TestGen(unittest.TestCase):
             with open(confname, 'r') as F:
                 content = F.read()
 
-            self.assertEqual(content, """
-[instname]
+            self.assertEqual(content,
+"""[instname]
 command = /bin/sh -c blah
 chdir = /somedir
+
 """)
 
             main(getargs(['add',
@@ -37,34 +38,37 @@ chdir = /somedir
             with open(confname, 'r') as F:
                 content = F.read()
 
-            self.assertEqual(content, """
-[other]
+            self.assertEqual(content, 
+"""[other]
 command = /bin/sh -c blah
 chdir = /somedir
 user = someone
 group = controls
+
 """)
 
     def test_remove(self):
         with TestDir() as t:
             # we won't remove this config, so it should not be touched
             with open(t.dir+'/procServ.d/other.conf', 'w') as F:
-                F.write("""
-[other]
+                F.write(
+"""[other]
 command = /bin/sh -c blah
 chdir = /somedir
 user = someone
 group = controls
+
 """)
 
             confname = t.dir+'/procServ.d/blah.conf'
             with open(confname, 'w') as F:
-                F.write("""
-[blah]
+                F.write(
+"""[blah]
 command = /bin/sh -c blah
 chdir = /somedir
 user = someone
 group = controls
+
 """)
 
             main(getargs(['remove', '-f', 'blah']), test=True)
@@ -74,8 +78,8 @@ group = controls
 
             confname = t.dir+'/procServ.d/blah.conf'
             with open(confname, 'w') as F:
-                F.write("""
-[blah]
+                F.write(
+"""[blah]
 command = /bin/sh -c blah
 chdir = /somedir
 user = someone

--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,5 @@ setup(
         ('lib/systemd/user-generators', ['systemd-procserv-generator-user']),
     ],
     cmdclass = { 'install_data': custom_install_data },
+    #install_requires=['argcomplete', 'tabulate', 'termcolor'],
 )


### PR DESCRIPTION
Hello, 
this PR adds some functionalities to the procServUtils scripts:

1. Bash autocomplete through `argcomplete`
1. New commands to restart, rename or open logs of the processes
1. Print `status` as a table with color support, to be easier to read
1. Fix some unhandled exceptions
1. Documentation for the commands

To enable these functionalities three python dependencies are needed: `argcomplete`, `tabulate` and `termcolor`. Unfortunately the current installation process does not support installing dependencies so one has to install them manually through pip.

Do you think the installation process can be modified to use pip to automatically handle dependencies?

All the changes here are compatible with existing configuration files and do not break compatibility (hopefully).