### PR TITLE
Modify restartMode oneshot feature to not halt while toggling

### DIFF
--- a/clientFactory.cc
+++ b/clientFactory.cc
@@ -222,7 +222,10 @@ void clientItem::processInput(const char *buf, int len)
             }
             if (toggleRestartChar && buf[i] == toggleRestartChar) {
                 if (restartMode == restart) restartMode = norestart;
-                else if (restartMode == norestart) restartMode = oneshot;
+                else if (restartMode == norestart) {
+                    restartMode = oneshot;
+                    firstRun    = true;	// Allow process to run once AFTER selecting oneshot
+                }
                 else restartMode = restart;
                 char msg[128] = NL;
                 PRINTF ("Got a toggleAutoRestart command\n");

--- a/procServ.cc
+++ b/procServ.cc
@@ -56,6 +56,7 @@ bool   quiet = false;            // Suppress info output (server)
 bool   setCoreSize = false;      // Set core size for child
 bool   singleEndpointStyle = true;  // Compatibility style: first non-option is endpoint
 RestartMode restartMode = restart;  // Child restart mode (restart/norestart/oneshot)
+bool   firstRun;                 // Has process run for purposes of oneshot restart mode
 char   *procservName;            // The name of this beast (server)
 char   *childName;               // The name of that beast (child)
 char   *childExec;               // Exec to run as child
@@ -214,7 +215,6 @@ int main(int argc,char * argv[])
     const size_t BUFLEN = 512;
     char buff[BUFLEN];
     std::string infofile;
-    bool firstRun;
 
     time(&procServStart);             // remember start time
     procservName = argv[0];

--- a/procServ.h
+++ b/procServ.h
@@ -40,6 +40,7 @@ extern bool   waitForManualStart;
 extern volatile bool shutdownServer;
 extern bool   setCoreSize;
 extern RestartMode restartMode;
+extern bool   firstRun;
 extern char   *procservName;
 extern char   *childName;
 extern char   *ignChars;


### PR DESCRIPTION
Got many complaints from developers when we rolled out new procServ oneshot mode.
If IOC process is not running and the developer tries to change restartMode, it kills procServ
when the developer toggles through oneshot mode.

This commit sets firstRun true as restartMode is toggled.
Thus, developers can toggle through oneshot mode w/o killing procServ
and the IOC will run at least once before oneshot mode will kill procServ.