### PR TITLE
Notify clients when a kill command is received

### DIFF
--- a/clientFactory.cc
+++ b/clientFactory.cc
@@ -234,7 +234,9 @@ void clientItem::processInput(const char *buf, int len)
                 SendToAll(msg, strlen(msg), NULL);
             }
             if (killChar && buf[i] == killChar) {
+                const char *msg = NL "@@@ Got a kill command" NL;
                 PRINTF ("Got a kill command\n");
+                SendToAll(msg, strlen(msg), NULL);
                 processFactorySendSignal(killSig);
             }
         }


### PR DESCRIPTION
Currently, it is not possible to distinguish between the target process getting killed by a kill command, or getting killed by something else (for example, the OOM killer), this change intends to make it clear without having to use the debug flag (which generates too much information to be used in production)