### PR TITLE
return special exit code when children is killed by signal

### DIFF
--- a/procServ.cc
+++ b/procServ.cc
@@ -799,6 +799,10 @@ void OnPollTimeout()
             snprintf(buf+strlen(buf), BUFLEN-strlen(buf),
                      " The process was killed by signal %d",
                      WTERMSIG(wstatus));
+            // In order to exit as if we were killed, by returning e.g. 137 if
+            // killed by SIGKILL.
+            // See: https://tldp.org/LDP/abs/html/exitcodes.html
+            childExitCode = 128 + WTERMSIG(wstatus);
         }
         strncat(buf, NL, BUFLEN-strlen(buf)-1);
         SendToAll(buf, strlen(buf), NULL);


### PR DESCRIPTION
Allows the process parent of procServ to check if the child was terminated abnormally.

Fixes #58.