### PR TITLE
Close logfile FD for child processes

### DIFF
--- a/procServ.cc
+++ b/procServ.cc
@@ -657,6 +657,9 @@ int main(int argc,char * argv[])
                   PRINTF("Option oneshot is set... exiting\n");
                   shutdownServer = true;
                 } else {
+		  if (logFileFD > 0) {
+		    fcntl(logFileFD, F_SETFD, FD_CLOEXEC);
+		  }
                   npi= processFactory(childExec, childArgv);
                   if (npi) AddConnection(npi);
                   if (firstRun) {


### PR DESCRIPTION
When the child processes are spawned, they inherit the logfile file descriptor.  If the procserv logs are rotated using the logrotate utility, then the child processes still have a open file handle on the original logfile before it gets rotated. This prevents the kernel from freeing up the space used even though the original logfile  has been deleted.  Over time, or with large logfiles, this can result in a lot of phantom space being used up in the log directory.

This PR closes the logfile file descriptor before exec()-ing the child processes, allowing the logfile to be rotated and cleaned up by the kernel.