### PR TITLE
Don't install manpage source with disabled docs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,12 +22,12 @@ EXTRA_DIST += README.md conserver.cf.example
 EXTRA_DIST += procServUtils
 EXTRA_DIST += systemd-procserv-generator-system systemd-procserv-generator-user
 
-doc_DATA = AUTHORS COPYING ChangeLog NEWS README.md procServ.txt
+doc_DATA = AUTHORS COPYING ChangeLog NEWS README.md
 
 if INSTALL_DOC
 
 dist_man1_MANS = procServ.1
-dist_doc_DATA = procServ.pdf procServ.html
+dist_doc_DATA = procServ.txt procServ.pdf procServ.html
 
 if WITH_SYSTEMD_UTILS
 dist_man1_MANS += manage-procs.1


### PR DESCRIPTION
Users should be able to disable documentation installation with `configure --enable-doc=no`. However, procServ.txt is still installed when that flag is provided. Teach automake how to properly honor the --enable-doc=no option by moving the manpage source file along with its generated files, guarded by `if INSTALL_DOC`.

---

This patch was suggested by @charles2910 when configuring a nodoc build profile for the Debian package. See full discussion in https://salsa.debian.org/debian/procserv/-/merge_requests/7.

Moving everything (`AUTHORS`, `ChangeLog`, etc) to be conditional on `INSTALL_DOC` seems more consistent with "don't install documentation", IMHO. But I don't know if installing the license file (or copyright) is something users should really be able to skip.  Let me know what you think.