### PR TITLE
More systemd friendly?

### DIFF
--- a/procServ.cc
+++ b/procServ.cc
@@ -477,7 +477,6 @@ int main(int argc,char * argv[])
     }
     std::vector<char*> argvBuf(argvStore.size()+1); // include trailing NULL
     for(size_t i=0, N=argvStore.size(); i<N; i++) {
-        fprintf(stderr, "ARG[%zu] = %s\n", i, argvStore[i].c_str());
         argvBuf[i] = argvStore[i].data();
     }
     childArgv = argvBuf.data();

--- a/procServ.cc
+++ b/procServ.cc
@@ -59,8 +59,6 @@ RestartMode restartMode = restart;  // Child restart mode (restart/norestart/one
 bool   firstRun;                 // Has process run for purposes of oneshot restart mode
 char   *procservName;            // The name of this beast (server)
 char   *childName;               // The name of that beast (child)
-char   *childExec;               // Exec to run as child
-char   **childArgv;              // Argv for child process
 int    connectionNo;             // Total number of connections
 char   *ignChars = NULL;         // Characters to ignore
 char   killChar = 0x18;          // Kill command character (default: ^X)
@@ -214,6 +212,7 @@ int main(int argc,char * argv[])
     const size_t BUFLEN = 512;
     char buff[BUFLEN];
     std::string infofile;
+    char *childExec = NULL;               // Exec to run as child
 
     time(&procServStart);             // remember start time
     procservName = argv[0];
@@ -455,7 +454,7 @@ int main(int argc,char * argv[])
     command = argv[optind];
 
     if (childName == NULL) childName = command;
-    childArgv = argv + optind - 1;
+    char** childArgv = argv + optind - 1;
     if (childExec == NULL) {
         childArgv++;
         childExec = command;

--- a/procServ.cc
+++ b/procServ.cc
@@ -460,6 +460,28 @@ int main(int argc,char * argv[])
         childExec = command;
     }
 
+    // reallocate argv[] storage, and expand any unexpanded arguments
+    std::vector<std::string> argvStore;
+    for(char** av = childArgv; *av; av++) {
+        if((*av)[0]=='$') { // expand command from environment
+            const char *ev = getenv(&(*av)[1]);
+            if(!ev) {
+                fprintf(stderr, "argument references %s which is not set in environment\n", *av);
+                exit(1);
+            }
+            argvStore.push_back(ev);
+
+        } else {
+            argvStore.push_back(*av);
+        }
+    }
+    std::vector<char*> argvBuf(argvStore.size()+1); // include trailing NULL
+    for(size_t i=0, N=argvStore.size(); i<N; i++) {
+        fprintf(stderr, "ARG[%zu] = %s\n", i, argvStore[i].c_str());
+        argvBuf[i] = argvStore[i].data();
+    }
+    childArgv = argvBuf.data();
+
     if (!stampFormat) {
         char *tmp = (char*) calloc(strlen(timeFormat)+4, 1);
         if (tmp) {

--- a/procServ@.service
+++ b/procServ@.service
@@ -1,0 +1,36 @@
+[Unit]
+Description="Managed process %i"
+
+[Service]
+Type=simple
+
+ExecStart=/usr/bin/procServ \
+  --foreground --logfile - --name %N \
+  --info-file %t/%N/info \
+  --port 0 \
+  --port unix:%t/%N/control \
+  $PROCCMD
+
+StandardOutput=syslog
+StandardError=inherit
+SyslogIdentifier=%N
+
+# Create %t/%N
+RuntimeDirectory=%N
+
+# What, where, who
+#Environment="PROCCMD=./st.cmd"
+#WorkingDirectory=/
+#User=softioc
+#Group=softioc
+
+# Permit RT priority for non-root
+#AmbientCapabilities=cap_ipc_lock
+#LimitRTPRIO=50
+#LimitMEMLOCK=256M
+
+[Install]
+# --system
+WantedBy=multi-user.target
+# --user
+#WantedBy=default.target


### PR DESCRIPTION
A half-baked idea for how to make procServ, with its long argument lists, friendlier for use with systemd.  Since systemd does not expand environment variables in `ExecStart=`, teach procServ to do so.

eg. `/etc/systemd/system/procServ@.service`

```
Environment="PROCCMD=false"
ExecStart=/usr/bin/procServ -f  ... $PROCCMD
```

This allows a unit override file to change only `$PROCCMD` without needing to repeat the whole long `ExecStart=`.

eg. `/etc/systemd/system/procServ@foo.service/override.conf`

```
Environment="PROCCMD=./st.cmd"
WorkingDirectory=/iocs/foo
User=softioc
Group=softioc
```

Would be a more concise expression of what, where, and who.

I'm not sure what the semantics would be to handle command arguments.  As written, this PR expands one environment variable as one argument.  eg `PROCCMD=foo bar` would `exec "foo bar"` instead of `exec "foo" "bar"` as might be expected.

Maybe a better way would be to do indirection for procServ argument values, and add a new argument for the un-split command?  eg.

```
procServ -P $PORT --cmd $PROCCMD
```
