### PR TITLE
Add grace period

### DIFF
--- a/manage-procs.md
+++ b/manage-procs.md
@@ -60,7 +60,7 @@ Increase verbosity level. (may be specified multiple times)
 
 # COMMANDS
 
-**manage-procs add** \[-h\] \[-f\] \[-A\] \[-C *dir*\] \[-P *port*\] \[-U *user*\] \[-G *group*\] *name* *command*…​  
+**manage-procs add** \[-h\] \[-f\] \[-A\] \[-C *dir*\] \[-P *port*\] \[-U *user*\] \[-G *group*\] *name* *command*…​
 Create a new procServ instance.
 
 **-h, --help**
@@ -89,11 +89,11 @@ Group name for instance to run as.
 **name**  
 Instance name.
 
-**command…​**  
+**command…​**
 The remaining line is interpreted as the command (with arguments) to run
 inside the procServ instance.
 
-**manage-procs remove** \[-h\] \[-f\] *name*  
+**manage-procs remove** \[-h\] \[-f\] *name*
 Remove an existing procServ instance from the configuration.
 
 **-h, --help**
@@ -102,30 +102,30 @@ Show a help message and exit.
 **-f, --force**
 Remove without asking for confirmation.
 
-**name**  
+**name**
 Instance name.
 
-**manage-procs start** \[-h\] \[*pattern*\]  
+**manage-procs start** \[-h\] \[*pattern*\]
 Start procServ instances.
 
 **-h, --help**
 Show a help message and exit.
 
-**pattern**  
+**pattern**
 Pattern to match existing instance names against. (default: "\*" = start
 all procServ instances)
 
-**manage-procs stop** \[-h\] \[*pattern*\]  
+**manage-procs stop** \[-h\] \[*pattern*\]
 Stop procServ instances.
 
 **-h, --help**
 Show a help message and exit.
 
-**pattern**  
+**pattern**
 Pattern to match existing instance names against. (default: "\*" = stop
 all procServ instances)
 
-**manage-procs attach** \[-h\] *name*  
+**manage-procs attach** \[-h\] *name*
 Attach to the control port of a running procServ instance.
 
 For this, manage-procs is using one of two existing CLI client
@@ -137,10 +137,10 @@ For both connection types, press `^D` to detach from the session.
 **-h, --help**
 Show a help message and exit.
 
-**name**  
+**name**
 Instance name.
 
-**manage-procs list** \[-h\] \[--all\]  
+**manage-procs list** \[-h\] \[--all\]
 List all procServ instances.
 
 **-h, --help**
@@ -149,7 +149,7 @@ Show a help message and exit.
 **--all**
 Also list inactive instances.
 
-**manage-procs status** \[-h\]  
+**manage-procs status** \[-h\]
 Report the status of all procServ instances.
 
 **-h, --help**

--- a/manage-procs.md
+++ b/manage-procs.md
@@ -86,7 +86,12 @@ User name for instance to run as.
 **-G, --group** *groupname*
 Group name for instance to run as.
 
-**name**  
+**-g, --grace-period** *n*
+Grace period (in seconds) that procServ will wait for the child to shut
+down after receiving a termination signal. (See procServ(1) for more
+details.)
+
+**name**
 Instance name.
 
 **command…​**

--- a/procServ.cc
+++ b/procServ.cc
@@ -654,17 +654,17 @@ int main(int argc,char * argv[])
             if (processFactoryNeedsRestart())
             {
                 if ((restartMode == oneshot) && !firstRun) {
-                  PRINTF("Option oneshot is set... exiting\n");
-                  shutdownServer = true;
+                    PRINTF("Option oneshot is set... exiting\n");
+                    shutdownServer = true;
                 } else {
-		  if (logFileFD > 0) {
-		    fcntl(logFileFD, F_SETFD, FD_CLOEXEC);
-		  }
-                  npi= processFactory(childExec, childArgv);
-                  if (npi) AddConnection(npi);
-                  if (firstRun) {
-                  	firstRun = false;
-                  }
+                    if (logFileFD > 0) {
+                        fcntl(logFileFD, F_SETFD, FD_CLOEXEC);
+                    }
+                    npi= processFactory(childExec, childArgv);
+                    if (npi) AddConnection(npi);
+                    if (firstRun) {
+                        firstRun = false;
+                    }
                 }
             }
         } else if (-1 == ready) {             // Error

--- a/procServ.cc
+++ b/procServ.cc
@@ -35,6 +35,7 @@
 #endif /* __CYGWIN__ */
 
 #include "procServ.h"
+#include "processClass.h"
 
 // Wrapper to ignore return values
 template<typename T>
@@ -214,6 +215,7 @@ int main(int argc,char * argv[])
     const size_t BUFLEN = 512;
     char buff[BUFLEN];
     std::string infofile;
+    unsigned int gracePeriod = 0;
 
     time(&procServStart);             // remember start time
     procservName = argv[0];
@@ -235,6 +237,7 @@ int main(int argc,char * argv[])
             {"debug",          no_argument,       0, 'd'},
             {"exec",           required_argument, 0, 'e'},
             {"foreground",     no_argument,       0, 'f'},
+            {"grace-period",   required_argument, 0, 'G'},
             {"help",           no_argument,       0, 'h'},
             {"holdoff",        required_argument, 0, 'H'},
             {"ignore",         required_argument, 0, 'i'},
@@ -308,6 +311,17 @@ int main(int argc,char * argv[])
             stampLog = true;
             if (optarg)
                 stampFormat = strdup(optarg);
+            break;
+
+        case 'G':
+            gracePeriod = atoi(optarg);
+            if (gracePeriod < 0) {
+                gracePeriod = 0;
+
+            } else if(gracePeriod < 1) {
+                // granularity below 2x pselect() timeout periods
+                gracePeriod = 1;
+            }
             break;
 
         case 'h':                                 // Help
@@ -594,6 +608,8 @@ int main(int argc,char * argv[])
         strncat(infoMessage1, buff, INFO1LEN-strlen(infoMessage1)-1);
     }
 
+    time_t stopAt = 0;
+
     firstRun = true;
     // Run here until something makes it die
     while ( ! shutdownServer )
@@ -623,6 +639,8 @@ int main(int argc,char * argv[])
 
         ready = pselect(nFd, &fdset, NULL, NULL, &timeout, &sigset_pselect);
         
+        time_t now = time(0);
+
         // Handle signals for which signal handlers were called while in pselect.
         
         if (sigPipeSet) {
@@ -635,7 +653,14 @@ int main(int argc,char * argv[])
             sigTermSet = 0;
             PRINTF("SigTerm received\n");
             processFactorySendSignal(killSig);
-            shutdownServer = true;
+            if(killSig==SIGKILL || gracePeriod<=0) {
+                shutdownServer = true;
+
+            } else if(!stopAt) {
+                restartMode = oneshot; // prevent restart
+                stopAt = now + gracePeriod; // wait a bit for child to stop
+                PRINTF("Start child cleanup timer %u sec.\n", gracePeriod);
+            }
         }
 
         if (sigHupSet) {
@@ -651,8 +676,9 @@ int main(int argc,char * argv[])
 
             // Pick up the process item if it dies
             // This call returns NULL if the process item lives
-            if (processFactoryNeedsRestart())
+            if (stopAt==0 && processFactoryNeedsRestart())
             {
+
                 if ((restartMode == oneshot) && !firstRun) {
                     PRINTF("Option oneshot is set... exiting\n");
                     shutdownServer = true;
@@ -679,6 +705,18 @@ int main(int argc,char * argv[])
                 p = p->next;
             }
             OnPollTimeout();
+        }
+
+        if(stopAt!=0) {
+            if(!processClass::hasRunning()) {
+                PRINTF("child exits\n");
+                shutdownServer = true;
+
+            } else if(now >= stopAt) {
+                PRINTF("child cleanup timer expires %ld, %ld\n", stopAt, now);
+                shutdownServer = true;
+                // connectionItem dtor will KILL
+            }
         }
     }
     ttySetCharNoEcho(false);

--- a/procServ.cc
+++ b/procServ.cc
@@ -175,7 +175,7 @@ void printHelp()
            " -d --debug               debug mode (keeps child in foreground)\n"
            " -e --exec <str>          specify child executable (default: arg0 of <command>)\n"
            " -f --foreground          keep child in foreground (interactive)\n"
-           " -G --grace-period <n>    wait <n> seconds for child to shut down\n"
+           " -g --grace-period <n>    wait <n> seconds for child to shut down\n"
            " -h --help                print this message\n"
            "    --holdoff <n>         set holdoff time [sec] between child restarts\n"
            " -i --ignore <str>        ignore all chars in <str> (^ for ctrl)\n"
@@ -238,7 +238,7 @@ int main(int argc,char * argv[])
             {"debug",          no_argument,       0, 'd'},
             {"exec",           required_argument, 0, 'e'},
             {"foreground",     no_argument,       0, 'f'},
-            {"grace-period",   required_argument, 0, 'G'},
+            {"grace-period",   required_argument, 0, 'g'},
             {"help",           no_argument,       0, 'h'},
             {"holdoff",        required_argument, 0, 'H'},
             {"ignore",         required_argument, 0, 'i'},
@@ -265,8 +265,8 @@ int main(int argc,char * argv[])
         /* getopt_long stores the option index here. */
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "+c:de:fG:hi:I:k:l:L:n:op:P:qVwx:",
-                         long_options, &option_index);
+        c = getopt_long(argc, argv, "+c:de:fg:hi:I:k:l:L:n:op:P:qVwx:",
+                        long_options, &option_index);
 
         /* Detect the end of the options. */
         if (c == -1) break;
@@ -314,7 +314,7 @@ int main(int argc,char * argv[])
                 stampFormat = strdup(optarg);
             break;
 
-        case 'G':
+        case 'g':
             k = atoi(optarg);
             if (k < 0) {
                 k = 0;

--- a/procServ.cc
+++ b/procServ.cc
@@ -706,7 +706,7 @@ int main(int argc,char * argv[])
         }
 
         if(stopAt!=0) {
-            if(!processClass::hasRunning()) {
+            if(!processClass::exists()) {
                 PRINTF("child exits\n");
                 shutdownServer = true;
 

--- a/procServ.cc
+++ b/procServ.cc
@@ -857,34 +857,31 @@ void OnPollTimeout()
 void AddConnection(connectionItem * ci)
 {
     PRINTF("Adding connection %p to list\n", ci);
-    if (connectionItem::head )
-	{
-	    ci->next=connectionItem::head;
-	    ci->next->prev=ci;
-	}
-	else ci->next=NULL;
-	
-	ci->prev=NULL;
-	connectionItem::head=ci;
-	connectionNo++;
+    if (connectionItem::head) {
+        ci->next = connectionItem::head;
+        ci->next->prev = ci;
+    } else
+        ci->next = NULL;
+
+    ci->prev = NULL;
+    connectionItem::head = ci;
+    connectionNo++;
 }
 
 
 void DeleteConnection(connectionItem *ci)
 {
     PRINTF("Deleting connection %p\n", ci);
-    if (ci->prev) // Not the head
-	{
-		ci->prev->next=ci->next;
-	}
-	else
-	{
-		connectionItem::head = ci->next;
-	}
-	if (ci->next) ci->next->prev=ci->prev;
+    if (ci->prev) { // Not the head
+        ci->prev->next = ci->next;
+    } else {
+        connectionItem::head = ci->next;
+    }
+    if (ci->next)
+        ci->next->prev = ci->prev;
     delete ci;
-	connectionNo--;
-	assert(connectionNo>=0);
+    connectionNo--;
+    assert(connectionNo >= 0);
 }
 
 static void OnSigPipe(int)

--- a/procServ.cc
+++ b/procServ.cc
@@ -651,7 +651,7 @@ int main(int argc,char * argv[])
             sigTermSet = 0;
             PRINTF("SigTerm received\n");
             processFactorySendSignal(killSig);
-            if(killSig==SIGKILL || gracePeriod<=0) {
+            if(killSig==SIGKILL || gracePeriod==0) {
                 shutdownServer = true;
 
             } else if(!stopAt) {
@@ -867,7 +867,6 @@ void AddConnection(connectionItem * ci)
     connectionItem::head = ci;
     connectionNo++;
 }
-
 
 void DeleteConnection(connectionItem *ci)
 {

--- a/procServ.cc
+++ b/procServ.cc
@@ -175,6 +175,7 @@ void printHelp()
            " -d --debug               debug mode (keeps child in foreground)\n"
            " -e --exec <str>          specify child executable (default: arg0 of <command>)\n"
            " -f --foreground          keep child in foreground (interactive)\n"
+           " -G --grace-period <n>    wait <n> seconds for child to shut down\n"
            " -h --help                print this message\n"
            "    --holdoff <n>         set holdoff time [sec] between child restarts\n"
            " -i --ignore <str>        ignore all chars in <str> (^ for ctrl)\n"
@@ -264,7 +265,7 @@ int main(int argc,char * argv[])
         /* getopt_long stores the option index here. */
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "+c:de:fhi:I:k:l:L:n:op:P:qVwx:",
+        c = getopt_long (argc, argv, "+c:de:fG:hi:I:k:l:L:n:op:P:qVwx:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -314,14 +315,11 @@ int main(int argc,char * argv[])
             break;
 
         case 'G':
-            gracePeriod = atoi(optarg);
-            if (gracePeriod < 0) {
-                gracePeriod = 0;
-
-            } else if(gracePeriod < 1) {
-                // granularity below 2x pselect() timeout periods
-                gracePeriod = 1;
+            k = atoi(optarg);
+            if (k < 0) {
+                k = 0;
             }
+            gracePeriod = (unsigned int) k;
             break;
 
         case 'h':                                 // Help

--- a/procServ.cc
+++ b/procServ.cc
@@ -18,13 +18,13 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <sys/types.h> 
+#include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <getopt.h>
-#include <sys/wait.h> 
+#include <sys/wait.h>
 #include <signal.h>
-#include <unistd.h> 
+#include <unistd.h>
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
@@ -140,7 +140,7 @@ void writePidFile(int pid)
     fclose(fp);
 }
 
-char getOptionChar ( const char* buf ) 
+char getOptionChar ( const char* buf )
 {
     if ( buf == NULL || buf[0] == 0 ) return 0;
     if ( buf[0] == '^' && buf[1] == '^' ) {
@@ -196,7 +196,7 @@ void printHelp()
            " -V --version             print program version\n"
            " -w --wait                wait for cmd on control connection to start child\n"
            " -x --logoutcmd <str>     command to logout client connection (^ for ctrl)\n"
-        );
+           );
 }
 
 void printVersion()
@@ -487,13 +487,13 @@ int main(int argc,char * argv[])
     memset(&sig, 0, sizeof(sig));
 
     PRINTF("Installing signal handlers\n");
-    
+
     // SIGPIPE, SIGTERM and SIGHUP will be handled in the main loop
     // with the assistance of pselect. This means that we have them
     // blocked outside of pselect call, but unblocked atomically
     // within pselect. Each time pselect returns, we safely check if
     // any of the signals were received.
-    
+
     // Block the signals that we bill be handling in the main loop.
     // At the same time, retrieve the original signal mask before
     // blocking, to be passed to pselect.
@@ -504,7 +504,7 @@ int main(int argc,char * argv[])
     sigaddset(&sigset_block, SIGTERM);
     sigaddset(&sigset_block, SIGHUP);
     sigprocmask(SIG_BLOCK, &sigset_block, &sigset_pselect);
-    
+
     sig.sa_handler = &OnSigPipe;              // sigaction() needed for Solaris
     sigaction(SIGPIPE, &sig, NULL);
     sig.sa_handler = &OnSigTerm;
@@ -580,7 +580,7 @@ int main(int argc,char * argv[])
         AddConnection(clientFactory(0));
     }
 
-    // Record some useful data for managers 
+    // Record some useful data for managers
     snprintf(infoMessage1, INFO1LEN,
              "@@@ procServ server PID: %ld" NL
              "@@@ Server startup directory: %s" NL
@@ -597,10 +597,10 @@ int main(int argc,char * argv[])
     strncat(infoMessage1, buff, INFO1LEN-strlen(infoMessage1)-1);
     snprintf(infoMessage2, INFO2LEN, "@@@ Child \"%s\" is SHUT DOWN" NL, childName);
     if ( logFile ) {
-	if ( -1 == logFileFD )
+        if ( -1 == logFileFD )
             snprintf(buff, BUFLEN, "@@@ Child log file: unable to open log file %s" NL,
                      logFile );
-	else
+        else
             snprintf(buff, BUFLEN, "@@@ Child log file: %s" NL,
                      logFile );
         strncat(infoMessage1, buff, INFO1LEN-strlen(infoMessage1)-1);
@@ -636,17 +636,17 @@ int main(int argc,char * argv[])
         timeout.tv_nsec = 500000000l;
 
         ready = pselect(nFd, &fdset, NULL, NULL, &timeout, &sigset_pselect);
-        
+
         time_t now = time(0);
 
         // Handle signals for which signal handlers were called while in pselect.
-        
+
         if (sigPipeSet) {
             sigPipeSet = 0;
             sprintf( buf, "@@@ Got a sigPipe signal: Did the child close its tty?" NL);
             SendToAll( buf, strlen(buf), NULL );
         }
-        
+
         if (sigTermSet) {
             sigTermSet = 0;
             PRINTF("SigTerm received\n");
@@ -666,11 +666,11 @@ int main(int argc,char * argv[])
             PRINTF("SigHup received\n");
             openLogFile();
         }
-        
+
         if (0 == ready) {                     // Timeout
             // Go clean up dead connections
             OnPollTimeout();
-            connectionItem * npi; 
+            connectionItem * npi;
 
             // Pick up the process item if it dies
             // This call returns NULL if the process item lives
@@ -882,7 +882,7 @@ void DeleteConnection(connectionItem *ci)
 		connectionItem::head = ci->next;
 	}
 	if (ci->next) ci->next->prev=ci->prev;
-        delete ci;
+    delete ci;
 	connectionNo--;
 	assert(connectionNo>=0);
 }

--- a/procServ.md
+++ b/procServ.md
@@ -100,25 +100,25 @@ plus additional debug messages to stdout.
 Both control and log endpoints may be bound to either TCP or UNIX
 sockets (where supported). Allowed endpoint specifications are:
 
-**\<port\>**  
+**\<port\>**
 Bind to either 0.0.0.0:*\<port\>* (any) or 127.0.0.1:*\<port\>*
 (localhost) depending on the type of endpoint and the setting of **-r**
 (**--restrict**) and **--allow** options.
 
-**\<ifaceaddr\>:\<port\>**  
+**\<ifaceaddr\>:\<port\>**
 Bind to the specified interface address and *\<port\>*. The interface IP
 address *\<ifaceaddr\>* must be given in numeric form. Uses 127.0.0.1
 (localhost) for security reasons unless the **--allow** option is also
 used.
 
-**unix:\</path/to/socket\>**  
+**unix:\</path/to/socket\>**
 Bind to a named unix domain socket that will be created at the specified
 absolute or relative path. The server process must have permission to
 create files in the enclosing directory. The socket file will be owned
 by the uid and primary gid of the procServ server process with
 permissions 0666 (equivalent to a TCP socket bound to localhost).
 
-**unix:\<user\>:\<group\>:\<perm\>:\</path/to/socket\>**  
+**unix:\<user\>:\<group\>:\<perm\>:\</path/to/socket\>**
 Bind to a named unix domain socket that will be created at the specified
 absolute or relative path. The server process must have permission to
 create files in the enclosing directory. The socket file will be owned
@@ -128,7 +128,7 @@ Any of *\<user\>*, *\<group\>*, and/or *\<perm\>* may be omitted. E.g.
 socket with 0660 permissions and allow the "grp" group connect to it.
 This requires that procServ be run as root or a member of "grp".
 
-**unix:@\</path/to/socket\>**  
+**unix:@\</path/to/socket\>**
 Bind to an abstract unix domain socket (Linux specific). Abstract
 sockets do not exist on the filesystem, and have no permissions checks.
 They are functionally similar to a TCP socket bound to localhost, but
@@ -303,11 +303,11 @@ file or through a console access and logging facility (such as
 
 # ENVIRONMENT VARIABLES
 
-**PROCSERV_PID**  
+**PROCSERV_PID**
 Sets the file name to write the PID of the server process into. (See
 **-p** option.)
 
-**PROCSERV_DEBUG**  
+**PROCSERV_DEBUG**
 If set, procServ starts in debug mode. (See **-d** option.)
 
 # KNOWN PROBLEMS

--- a/procServ.md
+++ b/procServ.md
@@ -170,6 +170,13 @@ Run *file* as executable for child. Default is *command*.
 Keep the server process in the foreground and connected to the
 controlling terminal.
 
+**-g, --grace-period**=*n*
+Use in combination with **--killsig**:
+Wait at most *n* seconds for the child process to shut down after
+receiving the termination signal. If the child does not exit within this
+period, it will be force-killed.
+(Default is 0: the server shuts down and kills the child immediately.)
+
 **-h, --help**
 Print help message.
 

--- a/procServUtils/conf.py
+++ b/procServUtils/conf.py
@@ -58,6 +58,7 @@ _defaults = {
     'group':'nogroup',
     'chdir':'/',
     'port':'0',
+    'grace-period':'0',
     'instance':'1',
 }
 

--- a/procServUtils/launch.py
+++ b/procServUtils/launch.py
@@ -38,6 +38,7 @@ def main(args):
     chdir = conf.get(name, 'chdir')
     cmd   = conf.get(name, 'command')
     port  = conf.get(name, 'port')
+    grace = conf.get(name, 'grace-period')
 
     rundir = getrundir(user=user)
 
@@ -57,6 +58,7 @@ def main(args):
         '--chdir',chdir,
         '--info-file',os.path.join(rundir, 'procserv-%s'%name, 'info'), #/run/procserv-$NAME/info
         '--port', port if port != "0" else 'unix:%s/procserv-%s/control'%(rundir,name),
+        '--grace-period', grace,
     ]
 
     if args.debug>1:

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -144,6 +144,7 @@ chdir = %(chdir)s
         if args.username: F.write("user = %s\n"%args.username)
         if args.group: F.write("group = %s\n"%args.group)
         if args.port: F.write("port = %s\n"%args.port)
+        if args.grace_period: F.write("grace-period = %s\n"%args.grace_period)
         if args.environment:
             env_to_string = ' '.join("\"%s\""%e for e in args.environment)
             F.write("environment = %s\n"%env_to_string)
@@ -174,7 +175,10 @@ def delproc(conf, args):
 
         with open(cfile) as F:
             C = ConfigParser({'instance':'1'})
-            C.readfp(F)
+            if hasattr(C, 'read_file'):
+                C.read_file(F)
+            else:
+                C.readfp(F)
 
         if not C.has_section(args.name):
             continue
@@ -276,6 +280,7 @@ def getargs(args=None):
     S.add_argument('-P','--port', help='telnet port')
     S.add_argument('-U','--user', dest='username')
     S.add_argument('-G','--group')
+    S.add_argument('-g','--grace-period', help='grace period for child shutdown')
     S.add_argument('-e','--environment', action='append', help='Add an environment variable')
     S.add_argument('-E','--env-file', help='Environment file path')
     S.add_argument('-f','--force', action='store_true', default=False)

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -292,7 +292,7 @@ def getargs(args=None):
     S.set_defaults(func=delproc)
 
     S = SP.add_parser('write-procs-cf', help='Write conserver config')
-    S.add_argument('-f','--out',default='/etc/conserver/procs.cf') 
+    S.add_argument('-f','--out',default='/etc/conserver/procs.cf')
     S.add_argument('-R','--reload', action='store_true', default=False)
     S.set_defaults(func=writeprocs)
 

--- a/processClass.h
+++ b/processClass.h
@@ -29,6 +29,8 @@ public:
     static void restartOnce ();
     static bool exists() { return _runningItem ? true : false; }
     virtual ~processClass();
+    static inline
+    bool hasRunning() { return _runningItem; }
 protected:
     pid_t _pid;
     static processClass * _runningItem;

--- a/processClass.h
+++ b/processClass.h
@@ -27,10 +27,8 @@ public:
     virtual bool isProcess() const { return true; }
     virtual bool isLogger() const { return false; }
     static void restartOnce ();
-    static bool exists() { return _runningItem ? true : false; }
+    static inline bool exists() { return _runningItem; }
     virtual ~processClass();
-    static inline
-    bool hasRunning() { return _runningItem; }
 protected:
     pid_t _pid;
     static processClass * _runningItem;


### PR DESCRIPTION
Updated and completed version of @mdavidsaver's grace-period PR #70.
(rebase, add documentation, include in procServUtils, fix Python 3.12 compat issue)

Add `--grace-period` (short `-g`) flag. Combine with `--killsig` to allow time for a graceful child shutdown during procServ shutdown.

By default, no change.
If a killsig other than `SIGKILL` is selected along with a non-zero grace period, then when procServ receives SIGTERM:
- send killsig to child
- wait up to grace-period
- if child remains, then issue `SIGKILL`
- exit procServ

There are some whitespace changes in separate commits.
_This PR will be squashed before merging._
(closes #70)